### PR TITLE
Fixup total memory parsing logic

### DIFF
--- a/calc/direct_memory.go
+++ b/calc/direct_memory.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	DefaultDirectMemory = DirectMemory{Value: 10 * Mibi, Provenance: Default}
+	DefaultDirectMemory = DirectMemory{Value: 10 * Mebi, Provenance: Default}
 	DirectMemoryRE      = regexp.MustCompile(fmt.Sprintf("^-XX:MaxDirectMemorySize=(%s)$", SizePattern))
 )
 

--- a/calc/reserved_code_cache.go
+++ b/calc/reserved_code_cache.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	DefaultReservedCodeCache = ReservedCodeCache{Value: 240 * Mibi, Provenance: Default}
+	DefaultReservedCodeCache = ReservedCodeCache{Value: 240 * Mebi, Provenance: Default}
 	ReservedCodeCacheRE      = regexp.MustCompile(fmt.Sprintf("^-XX:ReservedCodeCacheSize=(%s)$", SizePattern))
 )
 

--- a/calc/size_test.go
+++ b/calc/size_test.go
@@ -31,7 +31,6 @@ func testSize(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	context("format", func() {
-
 		it("formats bytes", func() {
 			Expect(calc.Size{Value: 1023}.String()).To(Equal("0"))
 		})
@@ -40,28 +39,26 @@ func testSize(t *testing.T, context spec.G, it spec.S) {
 			Expect(calc.Size{Value: calc.Kibi + 1023}.String()).To(Equal("1K"))
 		})
 
-		it("formats Mibi", func() {
-			Expect(calc.Size{Value: calc.Mibi + 1023}.String()).To(Equal("1M"))
+		it("formats Mebi", func() {
+			Expect(calc.Size{Value: calc.Mebi + 1023}.String()).To(Equal("1M"))
 		})
 
 		it("formats Gibi", func() {
 			Expect(calc.Size{Value: calc.Gibi + 1023}.String()).To(Equal("1G"))
 		})
 
-		it("formats Tibi", func() {
-			Expect(calc.Size{Value: calc.Tibi + 1023}.String()).To(Equal("1T"))
+		it("formats Tebi", func() {
+			Expect(calc.Size{Value: calc.Tebi + 1023}.String()).To(Equal("1T"))
 		})
 
-		it("formats larger than Tibi", func() {
-			Expect(calc.Size{Value: (calc.Tibi * 1024) + 1023}.String()).To(Equal("1024T"))
+		it("formats larger than Tebi", func() {
+			Expect(calc.Size{Value: (calc.Tebi * 1024) + 1023}.String()).To(Equal("1024T"))
 		})
 	})
 
 	context("parse", func() {
-
 		it("parses bytes", func() {
 			Expect(calc.ParseSize("1")).To(Equal(calc.Size{Value: 1}))
-			Expect(calc.ParseSize("1b")).To(Equal(calc.Size{Value: 1}))
 		})
 
 		it("parses Kibi", func() {
@@ -69,9 +66,9 @@ func testSize(t *testing.T, context spec.G, it spec.S) {
 			Expect(calc.ParseSize("1K")).To(Equal(calc.Size{Value: calc.Kibi}))
 		})
 
-		it("parses Mibi", func() {
-			Expect(calc.ParseSize("1m")).To(Equal(calc.Size{Value: calc.Mibi}))
-			Expect(calc.ParseSize("1M")).To(Equal(calc.Size{Value: calc.Mibi}))
+		it("parses Mebi", func() {
+			Expect(calc.ParseSize("1m")).To(Equal(calc.Size{Value: calc.Mebi}))
+			Expect(calc.ParseSize("1M")).To(Equal(calc.Size{Value: calc.Mebi}))
 		})
 
 		it("parses Gibi", func() {
@@ -79,9 +76,9 @@ func testSize(t *testing.T, context spec.G, it spec.S) {
 			Expect(calc.ParseSize("1G")).To(Equal(calc.Size{Value: calc.Gibi}))
 		})
 
-		it("parses Tibi", func() {
-			Expect(calc.ParseSize("1t")).To(Equal(calc.Size{Value: calc.Tibi}))
-			Expect(calc.ParseSize("1T")).To(Equal(calc.Size{Value: calc.Tibi}))
+		it("parses Tebi", func() {
+			Expect(calc.ParseSize("1t")).To(Equal(calc.Size{Value: calc.Tebi}))
+			Expect(calc.ParseSize("1T")).To(Equal(calc.Size{Value: calc.Tebi}))
 		})
 
 		it("parses zero", func() {
@@ -124,4 +121,41 @@ func testSize(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("parse", func() {
+		it("parses bytes", func() {
+			Expect(calc.ParseUnit("")).To(Equal(int64(1)))
+			Expect(calc.ParseUnit("B")).To(Equal(int64(1)))
+		})
+
+		it("parses Kibi", func() {
+			Expect(calc.ParseUnit("kB")).To(Equal(calc.Kibi))
+			Expect(calc.ParseUnit("KB")).To(Equal(calc.Kibi))
+			Expect(calc.ParseUnit("KiB")).To(Equal(calc.Kibi))
+		})
+
+		it("parses Mebi", func() {
+			Expect(calc.ParseUnit("MB")).To(Equal(calc.Mebi))
+			Expect(calc.ParseUnit("MiB")).To(Equal(calc.Mebi))
+		})
+
+		it("parses Gibi", func() {
+			Expect(calc.ParseUnit("GB")).To(Equal(calc.Gibi))
+			Expect(calc.ParseUnit("GiB")).To(Equal(calc.Gibi))
+		})
+
+		it("parses Tebi", func() {
+			Expect(calc.ParseUnit("TB")).To(Equal(calc.Tebi))
+			Expect(calc.ParseUnit("TiB")).To(Equal(calc.Tebi))
+		})
+
+		it("trims whitespace", func() {
+			Expect(calc.ParseUnit("\t\r\n kB")).To(Equal(calc.Kibi))
+			Expect(calc.ParseUnit("GB \t\r\n")).To(Equal(calc.Gibi))
+		})
+
+		it("does not parse unknown units", func() {
+			_, err := calc.ParseUnit("X")
+			Expect(err).To(HaveOccurred())
+		})
+	})
 }

--- a/calc/stack.go
+++ b/calc/stack.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	DefaultStack = Stack{Value: 1 * Mibi, Provenance: Default}
+	DefaultStack = Stack{Value: 1 * Mebi, Provenance: Default}
 	StackRE      = regexp.MustCompile(fmt.Sprintf("^-Xss(%s)$", SizePattern))
 )
 

--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -41,7 +41,11 @@ func main() {
 			c  = helper.SecurityProvidersConfigurer{Logger: l}
 			d  = helper.LinkLocalDNS{Logger: l}
 			j  = helper.JavaOpts{Logger: l}
-			m  = helper.MemoryCalculator{Logger: l, MemoryLimitPath: helper.DefaultMemoryLimitPath}
+			m  = helper.MemoryCalculator{
+				Logger:          l,
+				MemoryLimitPath: helper.DefaultMemoryLimitPath,
+				MemoryInfoPath:  helper.DefaultMemoryInfoPath,
+			}
 			o  = helper.OpenSSLCertificateLoader{CertificateLoader: cl, Logger: l}
 			s8 = helper.SecurityProvidersClasspath8{Logger: l}
 			s9 = helper.SecurityProvidersClasspath9{Logger: l}

--- a/helper/java_opts.go
+++ b/helper/java_opts.go
@@ -23,7 +23,7 @@ import (
 	"github.com/paketo-buildpacks/libpak/bard"
 )
 
-type JavaOpts struct{
+type JavaOpts struct {
 	Logger bard.Logger
 }
 

--- a/helper/memory_calculator_test.go
+++ b/helper/memory_calculator_test.go
@@ -169,7 +169,7 @@ func testMemoryCalculator(t *testing.T, context spec.G, it spec.S) {
 				const s = `
 					MemTotal:       16400152 kB
 					MemFree:        10477724 kB
-					MemAvailable:       4136 mB
+					MemAvailable:   WILL NOT PARSE
 					Buffers:          112396 kB
 				`
 
@@ -190,7 +190,7 @@ func testMemoryCalculator(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("limits total memory to 64T", func() {
-				Expect(ioutil.WriteFile(memoryLimitPath, strconv.AppendInt([]byte{}, helper.MaxJVMSize + 1, 10), 0755)).To(Succeed())
+				Expect(ioutil.WriteFile(memoryLimitPath, strconv.AppendInt([]byte{}, helper.MaxJVMSize+1, 10), 0755)).To(Succeed())
 
 				Expect(m.Execute()).To(Equal(map[string]string{
 					"JAVA_TOOL_OPTIONS": "-XX:MaxDirectMemorySize=10M -Xmx68718950865K -XX:MaxMetaspaceSize=13870K -XX:ReservedCodeCacheSize=240M -Xss1M",
@@ -198,7 +198,7 @@ func testMemoryCalculator(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("limits total memory to container size if set", func() {
-				Expect(ioutil.WriteFile(memoryLimitPath, strconv.AppendInt([]byte{}, 10 * calc.Gibi, 10), 0755)).To(Succeed())
+				Expect(ioutil.WriteFile(memoryLimitPath, strconv.AppendInt([]byte{}, 10*calc.Gibi, 10), 0755)).To(Succeed())
 
 				Expect(m.Execute()).To(Equal(map[string]string{
 					"JAVA_TOOL_OPTIONS": "-XX:MaxDirectMemorySize=10M -Xmx9959889K -XX:MaxMetaspaceSize=13870K -XX:ReservedCodeCacheSize=240M -Xss1M",


### PR DESCRIPTION
* injects correct default memory info filepath
* allows specified suffixes when parsing memory.limit_in_bytes
* parses units from available memory instead of only matching kB
* no longer support nonstandard b and B suffixes when parsing memory size
* replace parsing error cases with warning and continue to next fallback
* formatting

Signed-off-by: Emily Casey <ecasey@vmware.com>

Please confirm the following:
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
