### PR TITLE
Fixes bug where libjvm was looking for BPL_JVM_HEADROOM 

### DIFF
--- a/helper/memory_calculator.go
+++ b/helper/memory_calculator.go
@@ -53,11 +53,23 @@ func (m MemoryCalculator) Execute() (map[string]string, error) {
 			HeadRoom:    DefaultHeadroom,
 			ThreadCount: DefaultThreadCount,
 		}
+		deprecatedHeadroom bool
 	)
 
 	if s, ok := os.LookupEnv("BPL_JVM_HEADROOM"); ok {
 		if c.HeadRoom, err = strconv.Atoi(s); err != nil {
 			return nil, fmt.Errorf("unable to convert $BPL_JVM_HEADROOM=%s to integer\n%w", s, err)
+		}
+		deprecatedHeadroom = true
+		m.Logger.Info("WARNING: BPL_JVM_HEADROOM is deprecated and will be removed, please switch to BPL_JVM_HEAD_ROOM")
+	}
+
+	if s, ok := os.LookupEnv("BPL_JVM_HEAD_ROOM"); ok {
+		if c.HeadRoom, err = strconv.Atoi(s); err != nil {
+			return nil, fmt.Errorf("unable to convert $BPL_JVM_HEAD_ROOM=%s to integer\n%w", s, err)
+		}
+		if deprecatedHeadroom {
+			m.Logger.Info("WARNING: You have set both BPL_JVM_HEAD_ROOM and BPL_JVM_HEADROOM. BPL_JVM_HEADROOM has been deprecated, so it will be ignored.")
 		}
 	}
 

--- a/helper/memory_calculator_test.go
+++ b/helper/memory_calculator_test.go
@@ -117,6 +117,40 @@ func testMemoryCalculator(t *testing.T, context spec.G, it spec.S) {
 				})
 			})
 
+			context("$BPL_JVM_HEAD_ROOM", func() {
+				it.Before(func() {
+					Expect(os.Setenv("BPL_JVM_HEAD_ROOM", "10")).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("BPL_JVM_HEAD_ROOM")).To(Succeed())
+				})
+
+				it("passes $BPL_JVM_HEAD_ROOM to calculator", func() {
+					Expect(m.Execute()).To(Equal(map[string]string{
+						"JAVA_TOOL_OPTIONS": "-XX:MaxDirectMemorySize=10M -Xmx417848K -XX:MaxMetaspaceSize=13870K -XX:ReservedCodeCacheSize=240M -Xss1M",
+					}))
+				})
+			})
+
+			context("$BPL_JVM_HEADROOM and $BPL_JVM_HEAD_ROOM", func() {
+				it.Before(func() {
+					Expect(os.Setenv("BPL_JVM_HEADROOM", "20")).To(Succeed())
+					Expect(os.Setenv("BPL_JVM_HEAD_ROOM", "10")).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("BPL_JVM_HEADROOM")).To(Succeed())
+					Expect(os.Unsetenv("BPL_JVM_HEAD_ROOM")).To(Succeed())
+				})
+
+				it("passes $BPL_JVM_HEAD_ROOM to calculator", func() {
+					Expect(m.Execute()).To(Equal(map[string]string{
+						"JAVA_TOOL_OPTIONS": "-XX:MaxDirectMemorySize=10M -Xmx417848K -XX:MaxMetaspaceSize=13870K -XX:ReservedCodeCacheSize=240M -Xss1M",
+					}))
+				})
+			})
+
 			context("$BPL_JVM_LOADED_CLASS_COUNT", func() {
 				it.Before(func() {
 					Expect(os.Setenv("BPL_JVM_LOADED_CLASS_COUNT", "100")).To(Succeed())


### PR DESCRIPTION
## Summary

Fixes bug where libjvm was looking for BPL_JVM_HEADROOM, however documentation for all JVM provider buildpacks says to use BPL_JVM_HEAD_ROOM.

This fix:

1. Continues to support BPL_JVM_HEADROOM
2. Logs a warning deprecation mesage when using BPL_JVM_HEADROOM, as it will be removed in the future.
3. Supports using BPL_JVM_HEAD_ROOM as is documented everywhere.
4. If both are set, it will use BPL_JVM_HEAD_ROOM and log a warning.

## Use Cases

Resolves #63 

## Checklist

* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
