### PR TITLE
Make memory calculator work with cgroups v2

### DIFF
--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -42,9 +42,10 @@ func main() {
 			d = helper.LinkLocalDNS{Logger: l}
 			j = helper.JavaOpts{Logger: l}
 			m = helper.MemoryCalculator{
-				Logger:          l,
-				MemoryLimitPath: helper.DefaultMemoryLimitPath,
-				MemoryInfoPath:  helper.DefaultMemoryInfoPath,
+				Logger:            l,
+				MemoryLimitPathV1: helper.DefaultMemoryLimitPathV1,
+				MemoryLimitPathV2: helper.DefaultMemoryLimitPathV2,
+				MemoryInfoPath:    helper.DefaultMemoryInfoPath,
 			}
 			o  = helper.OpenSSLCertificateLoader{CertificateLoader: cl, Logger: l}
 			s8 = helper.SecurityProvidersClasspath8{Logger: l}


### PR DESCRIPTION
## Summary
Make memory calculator work with both cgroups v1 and v2

## Use Cases
Docker 20.10 and containerd 1.4 implements cgroups v2. The memory limit file location has been moved to a new location eg /sys/fs/cgroup/memory/memory.limit_in_bytes -> /sys/fs/cgroup/memory.max

## Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
