### PR TITLE
GH issue 81

### DIFF
--- a/build.go
+++ b/build.go
@@ -105,7 +105,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			warn := color.New(color.FgYellow, color.Bold)
 
 			if jreSkipped {
-				b.Logger.Header(warn.Sprint("A JRE is available, but a JDK was specifically requested by the user. Using a JDK at runtime has security implications."))
+				b.Logger.Header(warn.Sprint("A JDK was specifically requested by the user. Using a JDK at runtime has security implications."))
 			} else {
 				b.Logger.Header(warn.Sprint("No valid JRE available, providing matching JDK instead. Using a JDK at runtime has security implications."))
 			}

--- a/build.go
+++ b/build.go
@@ -18,6 +18,7 @@ package libjvm
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/buildpacks/libcnb"
 	"github.com/heroku/color"
@@ -57,7 +58,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	v, _ := cr.Resolve("BP_JVM_VERSION")
 
 	jreSkipped := false
-	if t, _ := cr.Resolve("BP_JVM_TYPE"); t == "jdk" {
+	if t, _ := cr.Resolve("BP_JVM_TYPE"); strings.ToLower(t) == "jdk" {
 		jreSkipped = true
 	}
 
@@ -79,7 +80,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		}
 	}
 
-	// we need a JDK and we're not using the JDK as a JRE
+	// we need a JDK, we're not using the JDK as a JRE and the JRE has not been skipped
 	if jdkRequired && !(jreRequired && !jreAvailable) && !jreSkipped {
 		dep, err := dr.Resolve("jdk", v)
 		if err != nil {
@@ -101,14 +102,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		depJRE, err := dr.Resolve("jre", v)
 
 		if !jreAvailable || jreSkipped {
-
-			warn := color.New(color.FgYellow, color.Bold)
-
-			if jreSkipped {
-				b.Logger.Header(warn.Sprint("A JDK was specifically requested by the user. Using a JDK at runtime has security implications."))
-			} else {
-				b.Logger.Header(warn.Sprint("No valid JRE available, providing matching JDK instead. Using a JDK at runtime has security implications."))
-			}
+			b.warnIfJreNotUsed(jreAvailable, jreSkipped)
 
 			// This forces the contributed layer to be build + cache + launch so it's available everywhere
 			jrePlanEntry.Metadata["build"] = true
@@ -163,4 +157,24 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	}
 
 	return result, nil
+}
+
+func (b Build) warnIfJreNotUsed(jreAvailable, jreSkipped bool) {
+	msg := "Using a JDK at runtime has security implications."
+
+	if !jreAvailable && !jreSkipped {
+		msg = fmt.Sprintf("No valid JRE available, providing matching JDK instead. %s", msg)
+	}
+
+	if jreSkipped {
+		subMsg := "A JDK was specifically requested by the user"
+		if jreAvailable {
+			subMsg = fmt.Sprintf("%s, however a JRE is available", subMsg)
+		} else {
+			subMsg = fmt.Sprintf("%s and a JDK is the only option", subMsg)
+		}
+		msg = fmt.Sprintf("%s. %s", subMsg, msg)
+	}
+
+	b.Logger.Header(color.New(color.FgYellow, color.Bold).Sprint(msg))
 }

--- a/build_test.go
+++ b/build_test.go
@@ -20,8 +20,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/onsi/gomega/format"
-
 	"github.com/buildpacks/libcnb"
 	. "github.com/onsi/gomega"
 	"github.com/paketo-buildpacks/libpak"
@@ -200,7 +198,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(result.BOM.Entries[2].Name).To(Equal("jvmkill"))
 		Expect(result.BOM.Entries[2].Launch).To(BeTrue())
 	})
-	format.MaxLength = 6000
+
 	it("contributes JDK when no JRE and both a JDK and JRE are wanted", func() {
 		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: LaunchContribution})
 		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jre", Metadata: LaunchContribution})

--- a/build_test.go
+++ b/build_test.go
@@ -361,6 +361,15 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(result.Layers[0].(libjvm.JDK).LayerContributor.Dependency.ID).To(Equal("jdk"))
 			Expect(result.Layers[1].(libjvm.JRE).LayerContributor.Dependency.ID).To(Equal("jre"))
 
+			Expect(result.BOM.Entries).To(HaveLen(4))
+			Expect(result.BOM.Entries[0].Name).To(Equal("jdk"))
+			Expect(result.BOM.Entries[0].Launch).To(BeFalse())
+			Expect(result.BOM.Entries[0].Build).To(BeTrue())
+
+			Expect(result.BOM.Entries[1].Name).To(Equal("jre"))
+			Expect(result.BOM.Entries[1].Launch).To(BeTrue())
+			Expect(result.BOM.Entries[1].Build).To(BeTrue())
+
 		})
 	})
 }

--- a/build_test.go
+++ b/build_test.go
@@ -326,7 +326,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Layers[0].Name()).To(Equal("jdk"))
 			Expect(result.Layers[0].(libjvm.JRE).LayerContributor.Dependency.ID).To(Equal("jdk"))
-			Expect(result.Layers).To(HaveLen(4))
+
+			Expect(result.BOM.Entries[0].Name).To(Equal("jdk"))
+			Expect(result.BOM.Entries[0].Launch).To(BeTrue())
 		})
 
 		it("contributes JRE when specified explicitly in $BP_JVM_TYPE", func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
Resolves #81 

## Summary
Adds buildpack variable BP_JVM_TYPE which accepts values "JDK" or "JRE", with "JRE" being the default. This allows users to specify the JVM type provided at launch. Detailed messages are logged to indicate the type chosen and availability from dependencies.

## Use Cases
Some use cases are detailed in [Issue 81](https://github.com/paketo-buildpacks/libjvm/issues/81), example: users require access to JDK tools in the container when running in test/staging environment.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
