### PR TITLE
Added functionality from paketo-buildpacks/debug

### DIFF
--- a/build.go
+++ b/build.go
@@ -131,8 +131,10 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 			if IsBeforeJava9(depJRE.Version) {
 				helpers = append(helpers, "security-providers-classpath-8")
+				helpers = append(helpers, "debug-8")
 			} else {
 				helpers = append(helpers, "security-providers-classpath-9")
+				helpers = append(helpers, "debug-9")
 			}
 
 			h, be := libpak.NewHelperLayer(context.Buildpack, helpers...)

--- a/build_test.go
+++ b/build_test.go
@@ -113,6 +113,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"openssl-certificate-loader",
 			"security-providers-configurer",
 			"security-providers-classpath-8",
+			"debug-8",
 		}))
 	})
 
@@ -141,6 +142,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"openssl-certificate-loader",
 			"security-providers-configurer",
 			"security-providers-classpath-9",
+			"debug-9",
 		}))
 	})
 

--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -51,6 +51,8 @@ func main() {
 			o  = helper.OpenSSLCertificateLoader{CertificateLoader: cl, Logger: l}
 			s8 = helper.SecurityProvidersClasspath8{Logger: l}
 			s9 = helper.SecurityProvidersClasspath9{Logger: l}
+			d8 = helper.Debug8{Logger: l}
+			d9 = helper.Debug9{Logger: l}
 		)
 
 		file := "/etc/resolv.conf"
@@ -69,6 +71,8 @@ func main() {
 			"security-providers-classpath-8": s8,
 			"security-providers-classpath-9": s9,
 			"security-providers-configurer":  c,
+			"debug-8":                        d8,
+			"debug-9":                        d9,
 		})
 	})
 }

--- a/helper/debug_8.go
+++ b/helper/debug_8.go
@@ -1,0 +1,57 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/paketo-buildpacks/libpak/bard"
+)
+
+type Debug8 struct {
+	Logger bard.Logger
+}
+
+func (d Debug8) Execute() (map[string]string, error) {
+	if _, ok := os.LookupEnv("BPL_DEBUG_ENABLED"); !ok {
+		return nil, nil
+	}
+
+	var err error
+
+	port := "8000"
+	if s, ok := os.LookupEnv("BPL_DEBUG_PORT"); ok {
+		port = s
+	}
+
+	suspend := false
+	if s, ok := os.LookupEnv("BPL_DEBUG_SUSPEND"); ok {
+		suspend, err = strconv.ParseBool(s)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse $BPL_DEBUG_SUSPEND\n%w", err)
+		}
+	}
+
+	s := fmt.Sprintf("Debugging enabled on port %s", port)
+	if suspend {
+		s = fmt.Sprintf("%s, suspended on start", s)
+	}
+	d.Logger.Info(s)
+
+	var values []string
+	if s, ok := os.LookupEnv("JAVA_TOOL_OPTIONS"); ok {
+		values = append(values, s)
+	}
+
+	if suspend {
+		s = "y"
+	} else {
+		s = "n"
+	}
+
+	values = append(values,
+		fmt.Sprintf("-agentlib:jdwp=transport=dt_socket,server=y,address=%s,suspend=%s", port, s))
+
+	return map[string]string{"JAVA_TOOL_OPTIONS": strings.Join(values, " ")}, nil
+}

--- a/helper/debug_8_test.go
+++ b/helper/debug_8_test.go
@@ -1,0 +1,89 @@
+package helper_test
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/paketo-buildpacks/libjvm/helper"
+	"github.com/sclevine/spec"
+)
+
+func testDebug8(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+		d      = helper.Debug8{}
+	)
+
+	it("does nothing if $BPL_DEBUG_ENABLED is no set", func() {
+		Expect(d.Execute()).To(BeNil())
+	})
+
+	context("$BPL_DEBUG_ENABLED", func() {
+
+		it.Before(func() {
+			Expect(os.Setenv("BPL_DEBUG_ENABLED", "true")).
+				To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BPL_DEBUG_ENABLED")).To(Succeed())
+		})
+
+		it("contributes configuration", func() {
+			Expect(d.Execute()).To(Equal(map[string]string{
+				"JAVA_TOOL_OPTIONS": "-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n",
+			}))
+		})
+
+		context("$BPL_DEBUG_PORT", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BPL_DEBUG_PORT", "8001")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BPL_DEBUG_PORT")).To(Succeed())
+			})
+
+			it("contributes port configuration from $BPL_DEBUG_PORT", func() {
+				Expect(d.Execute()).To(Equal(map[string]string{
+					"JAVA_TOOL_OPTIONS": "-agentlib:jdwp=transport=dt_socket,server=y,address=8001,suspend=n",
+				}))
+			})
+		})
+
+		context("$BPL_DEBUG_SUSPEND", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BPL_DEBUG_SUSPEND", "true")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BPL_DEBUG_SUSPEND")).To(Succeed())
+			})
+
+			it("contributes suspend configuration from $BPL_DEBUG_SUSPEND", func() {
+				Expect(d.Execute()).To(Equal(map[string]string{
+					"JAVA_TOOL_OPTIONS": "-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=y",
+				}))
+			})
+		})
+
+		context("$JAVA_TOOL_OPTIONS", func() {
+			it.Before(func() {
+				Expect(os.Setenv("JAVA_TOOL_OPTIONS", "test-java-tool-options")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("JAVA_TOOL_OPTIONS")).To(Succeed())
+			})
+
+			it("contributes configuration appended to existing $JAVA_TOOL_OPTIONS", func() {
+				Expect(d.Execute()).To(Equal(map[string]string{
+					"JAVA_TOOL_OPTIONS": "test-java-tool-options -agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n",
+				}))
+			})
+		})
+
+	})
+}

--- a/helper/debug_9.go
+++ b/helper/debug_9.go
@@ -1,0 +1,57 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/paketo-buildpacks/libpak/bard"
+)
+
+type Debug9 struct {
+	Logger bard.Logger
+}
+
+func (d Debug9) Execute() (map[string]string, error) {
+	if _, ok := os.LookupEnv("BPL_DEBUG_ENABLED"); !ok {
+		return nil, nil
+	}
+
+	var err error
+
+	port := "*:8000" // Java 9+ address format
+	if s, ok := os.LookupEnv("BPL_DEBUG_PORT"); ok {
+		port = "*:" + s
+	}
+
+	suspend := false
+	if s, ok := os.LookupEnv("BPL_DEBUG_SUSPEND"); ok {
+		suspend, err = strconv.ParseBool(s)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse $BPL_DEBUG_SUSPEND\n%w", err)
+		}
+	}
+
+	s := fmt.Sprintf("Debugging enabled on port %s", port)
+	if suspend {
+		s = fmt.Sprintf("%s, suspended on start", s)
+	}
+	d.Logger.Info(s)
+
+	var values []string
+	if s, ok := os.LookupEnv("JAVA_TOOL_OPTIONS"); ok {
+		values = append(values, s)
+	}
+
+	if suspend {
+		s = "y"
+	} else {
+		s = "n"
+	}
+
+	values = append(values,
+		fmt.Sprintf("-agentlib:jdwp=transport=dt_socket,server=y,address=%s,suspend=%s", port, s))
+
+	return map[string]string{"JAVA_TOOL_OPTIONS": strings.Join(values, " ")}, nil
+}

--- a/helper/debug_9_test.go
+++ b/helper/debug_9_test.go
@@ -1,0 +1,88 @@
+package helper_test
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/libjvm/helper"
+	"github.com/sclevine/spec"
+)
+
+func testDebug9(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+		d      = helper.Debug9{}
+	)
+
+	it("does nothing if $BPL_DEBUG_ENABLED is no set", func() {
+		Expect(d.Execute()).To(BeNil())
+	})
+
+	context("$BPL_DEBUG_ENABLED", func() {
+
+		it.Before(func() {
+			Expect(os.Setenv("BPL_DEBUG_ENABLED", "true")).
+				To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BPL_DEBUG_ENABLED")).To(Succeed())
+		})
+
+		it("contributes configuration", func() {
+			Expect(d.Execute()).To(Equal(map[string]string{
+				"JAVA_TOOL_OPTIONS": "-agentlib:jdwp=transport=dt_socket,server=y,address=*:8000,suspend=n",
+			}))
+		})
+
+		context("$BPL_DEBUG_PORT", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BPL_DEBUG_PORT", "8001")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BPL_DEBUG_PORT")).To(Succeed())
+			})
+
+			it("contributes port configuration from $BPL_DEBUG_PORT", func() {
+				Expect(d.Execute()).To(Equal(map[string]string{
+					"JAVA_TOOL_OPTIONS": "-agentlib:jdwp=transport=dt_socket,server=y,address=*:8001,suspend=n",
+				}))
+			})
+		})
+
+		context("$BPL_DEBUG_SUSPEND", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BPL_DEBUG_SUSPEND", "true")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BPL_DEBUG_SUSPEND")).To(Succeed())
+			})
+
+			it("contributes suspend configuration from $BPL_DEBUG_SUSPEND", func() {
+				Expect(d.Execute()).To(Equal(map[string]string{
+					"JAVA_TOOL_OPTIONS": "-agentlib:jdwp=transport=dt_socket,server=y,address=*:8000,suspend=y",
+				}))
+			})
+		})
+
+		context("$JAVA_TOOL_OPTIONS", func() {
+			it.Before(func() {
+				Expect(os.Setenv("JAVA_TOOL_OPTIONS", "test-java-tool-options")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("JAVA_TOOL_OPTIONS")).To(Succeed())
+			})
+
+			it("contributes configuration appended to existing $JAVA_TOOL_OPTIONS", func() {
+				Expect(d.Execute()).To(Equal(map[string]string{
+					"JAVA_TOOL_OPTIONS": "test-java-tool-options -agentlib:jdwp=transport=dt_socket,server=y,address=*:8000,suspend=n",
+				}))
+			})
+		})
+
+	})
+}

--- a/helper/init_test.go
+++ b/helper/init_test.go
@@ -34,5 +34,7 @@ func TestUnit(t *testing.T) {
 	suite("SecurityProvidersClasspath8", testSecurityProvidersClasspath8)
 	suite("SecurityProvidersClasspath9", testSecurityProvidersClasspath9)
 	suite("SecurityProvidersConfigurer", testSecurityProvidersConfigurer)
+	suite("Debug8", testDebug8)
+	suite("Debug9", testDebug9)
 	suite.Run(t)
 }


### PR DESCRIPTION
...to new helpers for Java 8 & 9, as debug configuration differs between versions.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
The buildpack paketo-buildpacks/debug will soon be archived - this PR adds the functionality from the Debug buildpack into libjvm (via a helper executed at runtime) making it available to all JVM Provider buildpacks.

## Use Cases
The flag '$BP_DEBUG_ENABLED' is no longer required to contribute Debug support via a buildpack. Debug support can simply be enabled at runtime, as before, with the environment variable $BPL_DEBUG_ENABLED set to `true`. 

Custom options can be set at runtime with the same environment variables as before:

* $BPL_DEBUG_PORT - What port the debug agent will listen on. Defaults to `8000`
* $BPL_DEBUG_SUSPEND - Whether the JVM will suspend execution until a debugger has attached. Defaults to `n`

Debug configuration will be contributed as before to `$JAVA_TOOL_OPTIONS`

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
