### PR TITLE
Added functionality from paketo-buildpacks/jmx to new jmx helper

### DIFF
--- a/build.go
+++ b/build.go
@@ -127,7 +127,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 		if IsLaunchContribution(jrePlanEntry.Metadata) {
 			helpers := []string{"active-processor-count", "java-opts", "jvm-heap", "link-local-dns", "memory-calculator",
-				"openssl-certificate-loader", "security-providers-configurer"}
+				"openssl-certificate-loader", "security-providers-configurer", "jmx"}
 
 			if IsBeforeJava9(depJRE.Version) {
 				helpers = append(helpers, "security-providers-classpath-8")

--- a/build_test.go
+++ b/build_test.go
@@ -112,6 +112,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"memory-calculator",
 			"openssl-certificate-loader",
 			"security-providers-configurer",
+			"jmx",
 			"security-providers-classpath-8",
 			"debug-8",
 		}))
@@ -141,6 +142,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"memory-calculator",
 			"openssl-certificate-loader",
 			"security-providers-configurer",
+			"jmx",
 			"security-providers-classpath-9",
 			"debug-9",
 		}))

--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -53,6 +53,7 @@ func main() {
 			s9 = helper.SecurityProvidersClasspath9{Logger: l}
 			d8 = helper.Debug8{Logger: l}
 			d9 = helper.Debug9{Logger: l}
+			jm = helper.JMX{Logger: l}
 		)
 
 		file := "/etc/resolv.conf"
@@ -73,6 +74,7 @@ func main() {
 			"security-providers-configurer":  c,
 			"debug-8":                        d8,
 			"debug-9":                        d9,
+			"jmx":                            jm,
 		})
 	})
 }

--- a/helper/init_test.go
+++ b/helper/init_test.go
@@ -36,5 +36,6 @@ func TestUnit(t *testing.T) {
 	suite("SecurityProvidersConfigurer", testSecurityProvidersConfigurer)
 	suite("Debug8", testDebug8)
 	suite("Debug9", testDebug9)
+	suite("JMX", testJMX)
 	suite.Run(t)
 }

--- a/helper/jmx.go
+++ b/helper/jmx.go
@@ -1,0 +1,41 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/paketo-buildpacks/libpak/bard"
+)
+
+type JMX struct {
+	Logger bard.Logger
+}
+
+func (j JMX) Execute() (map[string]string, error) {
+	if _, ok := os.LookupEnv("BPL_JMX_ENABLED"); !ok {
+		return nil, nil
+	}
+
+	port := "5000"
+	if s, ok := os.LookupEnv("BPL_JMX_PORT"); ok {
+		port = s
+	}
+
+	j.Logger.Infof("JMX enabled on port %s", port)
+
+	var values []string
+	if s, ok := os.LookupEnv("JAVA_TOOL_OPTIONS"); ok {
+		values = append(values, s)
+	}
+
+	values = append(values,
+		"-Djava.rmi.server.hostname=127.0.0.1",
+		"-Dcom.sun.management.jmxremote.authenticate=false",
+		"-Dcom.sun.management.jmxremote.ssl=false",
+		fmt.Sprintf("-Dcom.sun.management.jmxremote.port=%s", port),
+		fmt.Sprintf("-Dcom.sun.management.jmxremote.rmi.port=%s", port),
+	)
+
+	return map[string]string{"JAVA_TOOL_OPTIONS": strings.Join(values, " ")}, nil
+}

--- a/helper/jmx_test.go
+++ b/helper/jmx_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helper_test
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/libjvm/helper"
+	"github.com/sclevine/spec"
+)
+
+func testJMX(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		j = helper.JMX{}
+	)
+
+	it("returns if $BPL_JMX_ENABLED is not set", func() {
+		Expect(j.Execute()).To(BeNil())
+	})
+
+	context("$BPL_JMX_ENABLED", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BPL_JMX_ENABLED", "")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BPL_JMX_ENABLED")).To(Succeed())
+		})
+
+		it("contributes configuration", func() {
+			Expect(j.Execute()).To(Equal(map[string]string{
+				"JAVA_TOOL_OPTIONS": "-Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=5000 -Dcom.sun.management.jmxremote.rmi.port=5000",
+			}))
+		})
+
+		context("$BPL_JMX_PORT", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BPL_JMX_PORT", "5001")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BPL_JMX_PORT")).To(Succeed())
+			})
+
+			it("contributes port configuration from $BPL_JMX_PORT", func() {
+				Expect(j.Execute()).To(Equal(map[string]string{
+					"JAVA_TOOL_OPTIONS": "-Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=5001 -Dcom.sun.management.jmxremote.rmi.port=5001",
+				}))
+			})
+		})
+
+		context("$JAVA_TOOL_OPTIONS", func() {
+			it.Before(func() {
+				Expect(os.Setenv("JAVA_TOOL_OPTIONS", "test-java-tool-options")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("JAVA_TOOL_OPTIONS")).To(Succeed())
+			})
+
+			it("contributes configuration appended to existing $JAVA_TOOL_OPTIONS", func() {
+				Expect(j.Execute()).To(Equal(map[string]string{
+					"JAVA_TOOL_OPTIONS": "test-java-tool-options -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=5000 -Dcom.sun.management.jmxremote.rmi.port=5000",
+				}))
+			})
+		})
+	})
+
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
The buildpack paketo-buildpacks/jmx will soon be archived - this PR adds the functionality from the JMX buildpack into libjvm (via a helper executed at runtime) making it available to all JVM Provider buildpacks.

## Use Cases
The flag '$BP_JMX_ENABLED' is no longer required to contribute JMX support via a buildpack. JMX support can simply be enabled at runtime, as before, with the environment variable $BPL_JMX_ENABLED set to true.

Custom options can be set at runtime with the same environment variables as before:

$BPL_JMX_PORT - What port the JMX connector will listen on. Defaults to `5000`.

JMX configuration will be contributed as before to $JAVA_TOOL_OPTIONS

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
