### PR TITLE
Added functionality for Java Native Memory Tracking to new helper - nmt

### DIFF
--- a/build.go
+++ b/build.go
@@ -127,7 +127,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 		if IsLaunchContribution(jrePlanEntry.Metadata) {
 			helpers := []string{"active-processor-count", "java-opts", "jvm-heap", "link-local-dns", "memory-calculator",
-				"openssl-certificate-loader", "security-providers-configurer", "jmx"}
+				"openssl-certificate-loader", "security-providers-configurer", "jmx", "nmt"}
 
 			if IsBeforeJava9(depJRE.Version) {
 				helpers = append(helpers, "security-providers-classpath-8")

--- a/build_test.go
+++ b/build_test.go
@@ -113,6 +113,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"openssl-certificate-loader",
 			"security-providers-configurer",
 			"jmx",
+			"nmt",
 			"security-providers-classpath-8",
 			"debug-8",
 		}))
@@ -143,6 +144,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"openssl-certificate-loader",
 			"security-providers-configurer",
 			"jmx",
+			"nmt",
 			"security-providers-classpath-9",
 			"debug-9",
 		}))

--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -54,6 +54,7 @@ func main() {
 			d8 = helper.Debug8{Logger: l}
 			d9 = helper.Debug9{Logger: l}
 			jm = helper.JMX{Logger: l}
+			n  = helper.NMT{Logger: l}
 		)
 
 		file := "/etc/resolv.conf"
@@ -75,6 +76,7 @@ func main() {
 			"debug-8":                        d8,
 			"debug-9":                        d9,
 			"jmx":                            jm,
+			"nmt":                            n,
 		})
 	})
 }

--- a/helper/init_test.go
+++ b/helper/init_test.go
@@ -37,5 +37,6 @@ func TestUnit(t *testing.T) {
 	suite("Debug8", testDebug8)
 	suite("Debug9", testDebug9)
 	suite("JMX", testJMX)
+	suite("NMT", testNMT)
 	suite.Run(t)
 }

--- a/helper/nmt.go
+++ b/helper/nmt.go
@@ -1,0 +1,37 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/paketo-buildpacks/libpak/bard"
+)
+
+type NMT struct {
+	Logger bard.Logger
+}
+
+func (n NMT) Execute() (map[string]string, error) {
+
+	if s, ok := os.LookupEnv("BPL_JAVA_NMT_ENABLED"); ok && strings.ToLower(s) == "false" {
+		n.Logger.Info("Disabling Java Native Memory Tracking")
+		return nil, nil
+	}
+	level := "summary"
+	if s, ok := os.LookupEnv("BPL_JAVA_NMT_LEVEL"); ok && strings.ToLower(s) == "detail" {
+		level = "detail"
+	}
+
+	n.Logger.Info("Enabling Java Native Memory Tracking")
+	var values []string
+	if s, ok := os.LookupEnv("JAVA_TOOL_OPTIONS"); ok {
+		values = append(values, s)
+	}
+	values = append(values, "-XX:+UnlockDiagnosticVMOptions", fmt.Sprintf("-XX:NativeMemoryTracking=%s", level), "-XX:+PrintNMTStatistics")
+
+	// NMT_LEVEL_1 Required for Java Native Memory Tracking to work due to bug which is not fixed until Java v18 (https://bugs.openjdk.java.net/browse/JDK-8256844)
+	// '1' = PID of Java process in the container. Value for NMT level should match that passed to '-XX:NativeMemoryTracking' in the NMT helper.
+	return map[string]string{"NMT_LEVEL_1": level, "JAVA_TOOL_OPTIONS": strings.Join(values, " ")}, nil
+
+}

--- a/helper/nmt_test.go
+++ b/helper/nmt_test.go
@@ -1,0 +1,69 @@
+package helper_test
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/libjvm/helper"
+	"github.com/sclevine/spec"
+)
+
+func testNMT(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		n = helper.NMT{}
+	)
+
+	it("returns if $BPL_JAVA_NMT_ENABLED is set to false", func() {
+		Expect(os.Setenv("BPL_JAVA_NMT_ENABLED", "false")).To(Succeed())
+		Expect(n.Execute()).To(BeNil())
+	})
+
+	context("$BPL_JAVA_NMT_ENABLED", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BPL_JAVA_NMT_ENABLED", "true")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BPL_JAVA_NMT_ENABLED")).To(Succeed())
+			Expect(os.Unsetenv("NMT_LEVEL_1")).To(Succeed())
+		})
+
+		it("contributes configuration for summary level", func() {
+
+			Expect(os.Setenv("BPL_JAVA_NMT_LEVEL", "summary")).To(Succeed())
+			Expect(n.Execute()).To(Equal(map[string]string{"NMT_LEVEL_1": "summary",
+				"JAVA_TOOL_OPTIONS": "-XX:+UnlockDiagnosticVMOptions -XX:NativeMemoryTracking=summary -XX:+PrintNMTStatistics",
+			}))
+			Expect(os.Unsetenv("BPL_JAVA_NMT_LEVEL")).To(Succeed())
+		})
+
+		it("contributes configuration for detail level", func() {
+
+			Expect(os.Setenv("BPL_JAVA_NMT_LEVEL", "detail")).To(Succeed())
+			Expect(n.Execute()).To(Equal(map[string]string{"NMT_LEVEL_1": "detail",
+				"JAVA_TOOL_OPTIONS": "-XX:+UnlockDiagnosticVMOptions -XX:NativeMemoryTracking=detail -XX:+PrintNMTStatistics",
+			}))
+			Expect(os.Unsetenv("BPL_JAVA_NMT_LEVEL")).To(Succeed())
+		})
+
+		context("$JAVA_TOOL_OPTIONS", func() {
+			it.Before(func() {
+				Expect(os.Setenv("JAVA_TOOL_OPTIONS", "test-java-tool-options")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("JAVA_TOOL_OPTIONS")).To(Succeed())
+			})
+
+			it("contributes configuration appended to existing $JAVA_TOOL_OPTIONS - level defaults to summary", func() {
+				Expect(n.Execute()).To(Equal(map[string]string{"NMT_LEVEL_1": "summary",
+					"JAVA_TOOL_OPTIONS": "test-java-tool-options -XX:+UnlockDiagnosticVMOptions -XX:NativeMemoryTracking=summary -XX:+PrintNMTStatistics",
+				}))
+			})
+		})
+	})
+
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This PR adds Java Native Memory Tracking (NMT) features as part of [RFC0003](https://github.com/paketo-buildpacks/rfcs/blob/main/text/java/0003-retire-kill-agent.md).
A helper has been added which sets the following required variables/flags to configure Java NMT:

* "NMT_LEVEL_1=summary" - required to enable NMT successfully due to [JDK bug](https://bugs.openjdk.java.net/browse/JDK-8256844)
* "-XX:+UnlockDiagnosticVMOptions"
* "-XX:NativeMemoryTracking=summary" - (summary report of memory usage)
* "-XX:+PrintNMTStatistics" - (prints memory usage data at VM exit)

These features will be enabled by default but come with a small amount of overhead - to disable Java NMT, users can set `BPL_JAVA_NMT_ENABLED=false` at runtime.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
