### PR TITLE
Fixed issue with Java NMT not working with Java 8

### DIFF
--- a/build.go
+++ b/build.go
@@ -127,7 +127,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 		if IsLaunchContribution(jrePlanEntry.Metadata) {
 			helpers := []string{"active-processor-count", "java-opts", "jvm-heap", "link-local-dns", "memory-calculator",
-				"openssl-certificate-loader", "security-providers-configurer", "jmx", "nmt"}
+				"openssl-certificate-loader", "security-providers-configurer", "jmx"}
 
 			if IsBeforeJava9(depJRE.Version) {
 				helpers = append(helpers, "security-providers-classpath-8")
@@ -135,6 +135,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			} else {
 				helpers = append(helpers, "security-providers-classpath-9")
 				helpers = append(helpers, "debug-9")
+				helpers = append(helpers, "nmt")
 			}
 
 			h, be := libpak.NewHelperLayer(context.Buildpack, helpers...)

--- a/build_test.go
+++ b/build_test.go
@@ -113,7 +113,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"openssl-certificate-loader",
 			"security-providers-configurer",
 			"jmx",
-			"nmt",
 			"security-providers-classpath-8",
 			"debug-8",
 		}))
@@ -144,9 +143,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"openssl-certificate-loader",
 			"security-providers-configurer",
 			"jmx",
-			"nmt",
 			"security-providers-classpath-9",
 			"debug-9",
+			"nmt",
 		}))
 	})
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Fixes paketo-buildpacks/bellsoft-liberica#131 - PR removes the NMT helper for pre-9 Java versions

## Use Cases
The JVM crashes for Java 8 users when `BPL_JAVA_NMT_ENABLED=true` (the default value) due to JDK bug

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
