### PR TITLE
Disabled reading of cacerts at build & run time for Java 18

### DIFF
--- a/build.go
+++ b/build.go
@@ -131,7 +131,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 		if IsLaunchContribution(jrePlanEntry.Metadata) {
 			helpers := []string{"active-processor-count", "java-opts", "jvm-heap", "link-local-dns", "memory-calculator",
-				"openssl-certificate-loader", "security-providers-configurer", "jmx", "jfr"}
+				"security-providers-configurer", "jmx", "jfr"}
 
 			if IsBeforeJava9(depJRE.Version) {
 				helpers = append(helpers, "security-providers-classpath-8")
@@ -140,6 +140,10 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 				helpers = append(helpers, "security-providers-classpath-9")
 				helpers = append(helpers, "debug-9")
 				helpers = append(helpers, "nmt")
+			}
+			// Java 18 bug - cacerts keystore type not readable
+			if IsBeforeJava18(depJRE.Version) {
+				helpers = append(helpers, "openssl-certificate-loader")
 			}
 
 			h, be := libpak.NewHelperLayer(context.Buildpack, helpers...)

--- a/build_test.go
+++ b/build_test.go
@@ -111,12 +111,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"jvm-heap",
 			"link-local-dns",
 			"memory-calculator",
-			"openssl-certificate-loader",
 			"security-providers-configurer",
 			"jmx",
 			"jfr",
 			"security-providers-classpath-8",
 			"debug-8",
+			"openssl-certificate-loader",
 		}))
 	})
 
@@ -142,13 +142,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"jvm-heap",
 			"link-local-dns",
 			"memory-calculator",
-			"openssl-certificate-loader",
 			"security-providers-configurer",
 			"jmx",
 			"jfr",
 			"security-providers-classpath-9",
 			"debug-9",
 			"nmt",
+			"openssl-certificate-loader",
 		}))
 	})
 

--- a/jre.go
+++ b/jre.go
@@ -23,6 +23,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/heroku/color"
+
 	"github.com/buildpacks/libcnb"
 	"github.com/magiconair/properties"
 	"github.com/paketo-buildpacks/libpak"
@@ -84,8 +86,12 @@ func (j JRE) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			cacertsPath = filepath.Join(layer.Path, "lib", "security", "cacerts")
 		}
 
-		if err := j.CertificateLoader.Load(cacertsPath, "changeit"); err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to load certificates\n%w", err)
+		if IsBeforeJava18(j.LayerContributor.Dependency.Version) {
+			if err := j.CertificateLoader.Load(cacertsPath, "changeit"); err != nil {
+				return libcnb.Layer{}, fmt.Errorf("unable to load certificates\n%w", err)
+			}
+		} else {
+			j.Logger.Bodyf("%s: The JVM cacerts entries cannot be loaded with Java 18, for more information see: https://github.com/paketo-buildpacks/libjvm/issues/158", color.YellowString("Warning"))
 		}
 
 		if IsBuildContribution(j.Metadata) {

--- a/versions.go
+++ b/versions.go
@@ -21,6 +21,7 @@ import (
 )
 
 var Java9, _ = semver.NewVersion("9")
+var Java18, _ = semver.NewVersion("18")
 
 func IsBeforeJava9(candidate string) bool {
 	v, err := semver.NewVersion(candidate)
@@ -29,4 +30,13 @@ func IsBeforeJava9(candidate string) bool {
 	}
 
 	return v.LessThan(Java9)
+}
+
+func IsBeforeJava18(candidate string) bool {
+	v, err := semver.NewVersion(candidate)
+	if err != nil {
+		return false
+	}
+
+	return v.LessThan(Java18)
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Workaround for #158 - this PR disables loading the default `cacerts` keystore & entries when using Java 18. The ca-certificates buildpack cannot be used with Java 18 until there is a permanent resolution.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
