### PR TITLE
Adds support for counting agent jar classes in memory calculator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 bin/
+.DS_Store

--- a/count/count_classes.go
+++ b/count/count_classes.go
@@ -18,7 +18,9 @@ package count
 
 import (
 	"archive/zip"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,7 +123,7 @@ func JarClassesFrom(paths ...string) (int, int, error) {
 	for _, path := range paths {
 		if c, err := JarClasses(path); err == nil {
 			agentClassCount += c
-		} else if strings.Contains(err.Error(), "no such file or directory") {
+		} else if errors.Is(err, fs.ErrNotExist) {
 			skippedPaths++
 			continue
 		} else {

--- a/count/count_classes.go
+++ b/count/count_classes.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 )
 
-var ClassExtensions = []string{".class", ".clj", ".groovy", ".kts"}
+var ClassExtensions = []string{".class", ".classdata", ".clj", ".groovy", ".kts"}
 
 func Classes(path string) (int, error) {
 	file := filepath.Join(path, "lib", "modules")
@@ -113,4 +113,20 @@ func ModuleClasses(file string) (int, error) {
 	}
 
 	return count, nil
+}
+
+func JarClassesFrom(paths ...string) (int, int, error) {
+	var agentClassCount, skippedPaths int
+
+	for _, path := range paths {
+		if c, err := JarClasses(path); err == nil {
+			agentClassCount += c
+		} else if strings.Contains(err.Error(), "no such file or directory") {
+			skippedPaths++
+			continue
+		} else {
+			return 0, 0, fmt.Errorf("unable to count classes of jar at %s\n%w", path, err)
+		}
+	}
+	return agentClassCount, skippedPaths, nil
 }

--- a/helper/memory_calculator.go
+++ b/helper/memory_calculator.go
@@ -243,7 +243,7 @@ func (m MemoryCalculator) CountAgentClasses(opts string) (int, error) {
 			if err != nil {
 				return 0, fmt.Errorf("error counting agent jar classes \n%w", err)
 			} else if skippedAgents > 0 {
-				m.Logger.Infof(`WARNING: could not count classes from all agent jars (skipped %d), class count and metaspace may not be sized correctly %d`, skippedAgents)
+				m.Logger.Infof(`WARNING: could not count classes from all agent jars (skipped %d), class count and metaspace may not be sized correctly`, skippedAgents)
 			}
 		}
 	}

--- a/helper/memory_calculator.go
+++ b/helper/memory_calculator.go
@@ -18,6 +18,7 @@ package helper
 
 import (
 	"fmt"
+	"github.com/mattn/go-shellwords"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -75,6 +76,12 @@ func (m MemoryCalculator) Execute() (map[string]string, error) {
 		}
 	}
 
+	var values []string
+	opts, ok := os.LookupEnv("JAVA_TOOL_OPTIONS")
+	if ok {
+		values = append(values, opts)
+	}
+
 	if s, ok := os.LookupEnv("BPL_JVM_LOADED_CLASS_COUNT"); ok {
 		if c.LoadedClassCount, err = strconv.Atoi(s); err != nil {
 			return nil, fmt.Errorf("unable to convert $BPL_JVM_LOADED_CLASS_COUNT=%s to integer\n%w", s, err)
@@ -94,6 +101,11 @@ func (m MemoryCalculator) Execute() (map[string]string, error) {
 			}
 		}
 
+		agentClassCount, err := m.CountAgentClasses(opts)
+		if err != nil {
+			return nil, err
+		}
+
 		staticAdjustment := 0
 		adjustmentFactor := uint64(100)
 		if adj, ok := os.LookupEnv("BPL_JVM_CLASS_ADJUSTMENT"); ok {
@@ -110,12 +122,12 @@ func (m MemoryCalculator) Execute() (map[string]string, error) {
 
 		appClassCount, err := count.Classes(appPath)
 
-		totalClasses := float64(jvmClassCount+appClassCount+staticAdjustment) * (float64(adjustmentFactor) / 100.0)
+		totalClasses := float64(jvmClassCount+appClassCount+agentClassCount+staticAdjustment) * (float64(adjustmentFactor) / 100.0)
 
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine class count\n%w", err)
 		}
-		m.Logger.Debugf("Memory Calculation: (%d%% * (%d + %d + %d)) * %0.2f", adjustmentFactor, jvmClassCount, appClassCount, staticAdjustment, ClassLoadFactor)
+		m.Logger.Debugf("Memory Calculation: (%d%% * (%d + %d + %d + %d)) * %0.2f", adjustmentFactor, jvmClassCount, appClassCount, agentClassCount, staticAdjustment, ClassLoadFactor)
 		c.LoadedClassCount = int(totalClasses * ClassLoadFactor)
 	}
 
@@ -154,13 +166,7 @@ func (m MemoryCalculator) Execute() (map[string]string, error) {
 		c.TotalMemory = calc.Size{Value: totalMemory}
 	}
 
-	var values []string
-	s, ok := os.LookupEnv("JAVA_TOOL_OPTIONS")
-	if ok {
-		values = append(values, s)
-	}
-
-	r, err := c.Calculate(s)
+	r, err := c.Calculate(opts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to calculate memory configuration\n%w", err)
 	}
@@ -219,4 +225,27 @@ func parseMemInfo(s string) (int64, error) {
 		return 0, err
 	}
 	return num * unit, nil
+}
+
+func (m MemoryCalculator) CountAgentClasses(opts string) (int, error) {
+	var agentClassCount, skippedAgents int
+	if p, err := shellwords.Parse(opts); err != nil {
+		return 0, fmt.Errorf("unable to parse $JAVA_TOOL_OPTIONS\n%w", err)
+	} else {
+		var agentPaths []string
+		for _, s := range p {
+			if strings.HasPrefix(s, "-javaagent:") {
+				agentPaths = append(agentPaths, strings.Split(s, ":")[1])
+			}
+		}
+		if len(agentPaths) > 0 {
+			agentClassCount, skippedAgents, err = count.JarClassesFrom(agentPaths...)
+			if err != nil {
+				return 0, fmt.Errorf("error counting agent jar classes \n%w", err)
+			} else if skippedAgents > 0 {
+				m.Logger.Infof(`WARNING: could not count classes from all agent jars (skipped %d), class count and metaspace may not be sized correctly %d`, skippedAgents)
+			}
+		}
+	}
+	return agentClassCount, nil
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Currently, if multiple agent jars are added to `JAVA_TOOL_OPTS`, the container can hit an OOM error due to a lack of Metaspace. This is because agent jar classes are not counted in the memory calculator and sufficient Metaspace is not reserved.
This PR counts the classes of agent jars in `JAVA_TOOL_OPTS`, the total of which is added to the memory calculator's equation.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
