### PR TITLE
Support SDKMAN RC files

### DIFF
--- a/build.go
+++ b/build.go
@@ -55,7 +55,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	cl := NewCertificateLoader()
 	cl.Logger = b.Logger.BodyWriter()
 
-	jvmVersion := JVMVersion{Logger: b.Logger}
+	jvmVersion := NewJVMVersion(b.Logger)
 	v, err := jvmVersion.GetJVMVersion(context.Application.Path, cr)
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to determine jvm version\n%w", err)

--- a/init_test.go
+++ b/init_test.go
@@ -41,6 +41,7 @@ func TestUnit(t *testing.T) {
 	suite("NewManifest", testNewManifest)
 	suite("NewManifestFromJAR", testNewManifestFromJAR)
 	suite("MavenJARListing", testMavenJARListing)
+	suite("SDKMAN", testSDKMAN)
 	suite("Versions", testVersions)
 	suite("JVMVersions", testJVMVersion)
 	suite.Run(t)

--- a/sdkman.go
+++ b/sdkman.go
@@ -65,9 +65,9 @@ func ReadSDKMANRC(path string) ([]SDKInfo, error) {
 			}
 
 			sdks = append(sdks, SDKInfo{
-				Type:    kv[0],
+				Type:    strings.ToLower(strings.TrimSpace(kv[0])),
 				Version: strings.TrimSpace(versionAndVendor[0]),
-				Vendor:  strings.TrimSpace(versionAndVendor[1]),
+				Vendor:  strings.ToLower(strings.TrimSpace(versionAndVendor[1])),
 			})
 		}
 	}

--- a/sdkman.go
+++ b/sdkman.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libjvm
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// SDKInfo represents the information from each line in the `.sdkmanrc` file
+type SDKInfo struct {
+	Type    string
+	Version string
+	Vendor  string
+}
+
+// ReadSDKMANRC reads the `.sdkmanrc` format file from path and retuns the list of SDKS in it
+func ReadSDKMANRC(path string) ([]SDKInfo, error) {
+	sdkmanrcContents, err := ioutil.ReadFile(path)
+	if err != nil {
+		return []SDKInfo{}, fmt.Errorf("unable to read SDKMANRC file at %s\n%w", path, err)
+	}
+
+	sdks := []SDKInfo{}
+	for _, line := range strings.Split(string(sdkmanrcContents), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		parts := strings.SplitN(line, "#", 2) // strip comments
+		if len(parts) != 1 && len(parts) != 2 {
+			return []SDKInfo{}, fmt.Errorf("unable to strip comments from %q resulted in %q", line, parts)
+		}
+
+		if strings.TrimSpace(parts[0]) != "" {
+			kv := strings.SplitN(parts[0], "=", 2) // split key=value
+			if len(kv) != 2 {
+				return []SDKInfo{}, fmt.Errorf("unable to split key/value from %q resulted in %q", parts[0], kv)
+			}
+
+			versionAndVendor := []string{"", ""}
+			if strings.TrimSpace(kv[1]) != "" {
+				versionAndVendor = strings.SplitN(kv[1], "-", 2) // split optional vendor name
+				if len(versionAndVendor) == 1 {
+					versionAndVendor = append(versionAndVendor, "")
+				}
+				if len(versionAndVendor) != 2 {
+					return []SDKInfo{}, fmt.Errorf("unable to split vendor from %q resulted in %q", kv[1], versionAndVendor)
+				}
+			}
+
+			sdks = append(sdks, SDKInfo{
+				Type:    kv[0],
+				Version: strings.TrimSpace(versionAndVendor[0]),
+				Vendor:  strings.TrimSpace(versionAndVendor[1]),
+			})
+		}
+	}
+
+	return sdks, nil
+}

--- a/sdkman_test.go
+++ b/sdkman_test.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libjvm_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/libjvm"
+	"github.com/sclevine/spec"
+)
+
+func testSDKMAN(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		path string
+	)
+
+	it.Before(func() {
+		var err error
+		path, err = ioutil.TempDir("", "sdkman")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(path)).To(Succeed())
+	})
+
+	it("parses single entry sdkmanrc file", func() {
+		sdkmanrcFile := filepath.Join(path, "sdkmanrc")
+		Expect(ioutil.WriteFile(sdkmanrcFile, []byte(`java=17.0.2-tem`), 0644)).To(Succeed())
+
+		res, err := libjvm.ReadSDKMANRC(sdkmanrcFile)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(Equal([]libjvm.SDKInfo{
+			{Type: "java", Version: "17.0.2", Vendor: "tem"},
+		}))
+	})
+
+	it("parses multiple entry sdkmanrc and doesn't care if there's overlap", func() {
+		sdkmanrcFile := filepath.Join(path, "sdkmanrc")
+		Expect(ioutil.WriteFile(sdkmanrcFile, []byte(`java=11.0.2-tem
+java=17.0.2-tem`), 0644)).To(Succeed())
+
+		res, err := libjvm.ReadSDKMANRC(sdkmanrcFile)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(Equal([]libjvm.SDKInfo{
+			{Type: "java", Version: "11.0.2", Vendor: "tem"},
+			{Type: "java", Version: "17.0.2", Vendor: "tem"},
+		}))
+	})
+
+	context("handles comments and whitespace", func() {
+		it("ignores full-line comments", func() {
+			sdkmanrcFile := filepath.Join(path, "sdkmanrc")
+			Expect(ioutil.WriteFile(sdkmanrcFile, []byte(`# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=17.0.2-tem
+    # has some leading whitespace`), 0644)).To(Succeed())
+
+			res, err := libjvm.ReadSDKMANRC(sdkmanrcFile)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal([]libjvm.SDKInfo{
+				{Type: "java", Version: "17.0.2", Vendor: "tem"},
+			}))
+		})
+
+		it("ignores trailing-line comments", func() {
+			sdkmanrcFile := filepath.Join(path, "sdkmanrc")
+			Expect(ioutil.WriteFile(sdkmanrcFile, []byte(`java=17.0.2-tem # comment`), 0644)).To(Succeed())
+
+			res, err := libjvm.ReadSDKMANRC(sdkmanrcFile)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal([]libjvm.SDKInfo{
+				{Type: "java", Version: "17.0.2", Vendor: "tem"},
+			}))
+		})
+
+		it("ignores empty lines", func() {
+			sdkmanrcFile := filepath.Join(path, "sdkmanrc")
+			Expect(ioutil.WriteFile(sdkmanrcFile, []byte(`
+# Enable auto-env through the sdkman_auto_env config
+              
+java=17.0.2-tem
+
+`), 0644)).To(Succeed())
+
+			res, err := libjvm.ReadSDKMANRC(sdkmanrcFile)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal([]libjvm.SDKInfo{
+				{Type: "java", Version: "17.0.2", Vendor: "tem"},
+			}))
+		})
+	})
+
+	context("handles malformed key/values", func() {
+		it("parses an empty value", func() {
+			sdkmanrcFile := filepath.Join(path, "sdkmanrc")
+			Expect(ioutil.WriteFile(sdkmanrcFile, []byte(`java=`), 0644)).To(Succeed())
+
+			res, err := libjvm.ReadSDKMANRC(sdkmanrcFile)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal([]libjvm.SDKInfo{
+				{Type: "java", Version: "", Vendor: ""},
+			}))
+		})
+
+		it("parses with an empty key", func() {
+			sdkmanrcFile := filepath.Join(path, "sdkmanrc")
+			Expect(ioutil.WriteFile(sdkmanrcFile, []byte(`=foo-vend`), 0644)).To(Succeed())
+
+			res, err := libjvm.ReadSDKMANRC(sdkmanrcFile)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal([]libjvm.SDKInfo{
+				{Type: "", Version: "foo", Vendor: "vend"},
+			}))
+		})
+
+		it("parses with an empty vendor", func() {
+			sdkmanrcFile := filepath.Join(path, "sdkmanrc")
+			Expect(ioutil.WriteFile(sdkmanrcFile, []byte(`foo=bar`), 0644)).To(Succeed())
+
+			res, err := libjvm.ReadSDKMANRC(sdkmanrcFile)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal([]libjvm.SDKInfo{
+				{Type: "foo", Version: "bar", Vendor: ""},
+			}))
+		})
+	})
+}

--- a/sdkman_test.go
+++ b/sdkman_test.go
@@ -55,6 +55,17 @@ func testSDKMAN(t *testing.T, context spec.G, it spec.S) {
 		}))
 	})
 
+	it("parses single entry sdkmanrc file and forces lowercase", func() {
+		sdkmanrcFile := filepath.Join(path, "sdkmanrc")
+		Expect(ioutil.WriteFile(sdkmanrcFile, []byte(` jAva = 17.0.2-TEM `), 0644)).To(Succeed())
+
+		res, err := libjvm.ReadSDKMANRC(sdkmanrcFile)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(Equal([]libjvm.SDKInfo{
+			{Type: "java", Version: "17.0.2", Vendor: "tem"},
+		}))
+	})
+
 	it("parses multiple entry sdkmanrc and doesn't care if there's overlap", func() {
 		sdkmanrcFile := filepath.Join(path, "sdkmanrc")
 		Expect(ioutil.WriteFile(sdkmanrcFile, []byte(`java=11.0.2-tem


### PR DESCRIPTION
## Summary

This PR includes support to read a '.sdkmanrc' file if it's present at the root of the application.

The version order is (from lowest to highest priority): Java buildpack default (11), Maven MANIFEST.MF properties, SDKMAN RC file, and BP_JVM_VERSION. Higher priority locations override lower priority locations. Note that Maven MANIFEST.MF entries only apply to pre-compiled assets (as MANIFEST.MF won't exist in a source build) and SDKMAN RC only applies when building from source (as it won't likely exist in a pre-compiled asset).

The buildpack will read the '.sdkmanrc' file, look for the 'java' component (if multiple, it picks the first one), and takes the major Java version indicated in the entry. It ignore minor/patch versions, it also ignores the vendor (the vendor is set based on the buildpack you use). The buildpack ignores other components.

## Use Cases

Developers commonly use the SDKMAN tool. It can write a `.sdkmanrc` file which can be used to indicate the Java version that's required by the application. The buildpack can read this file and use it to know which Java version to install.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
