### PR TITLE
Support for jlink to create custom JRE & reorg of build logic

### DIFF
--- a/build.go
+++ b/build.go
@@ -18,6 +18,8 @@ package libjvm
 
 import (
 	"fmt"
+	"github.com/mattn/go-shellwords"
+	"github.com/paketo-buildpacks/libpak/effect"
 	"strings"
 
 	"github.com/buildpacks/libcnb"
@@ -27,44 +29,27 @@ import (
 )
 
 type Build struct {
-	Logger bard.Logger
+	Logger          bard.Logger
+	Result          libcnb.BuildResult
+	CertLoader      CertificateLoader
+	DependencyCache libpak.DependencyCache
+}
+
+func NewBuild(logger bard.Logger) Build {
+	cl := NewCertificateLoader()
+	cl.Logger = logger.BodyWriter()
+
+	return Build{
+		Logger:     logger,
+		Result:     libcnb.NewBuildResult(),
+		CertLoader: cl,
+	}
 }
 
 func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
-	b.Logger.Title(context.Buildpack)
-	result := libcnb.NewBuildResult()
-
-	cr, err := libpak.NewConfigurationResolver(context.Buildpack, &b.Logger)
-	if err != nil {
-		return libcnb.BuildResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
-	}
+	var jdkRequired, jreRequired, jreMissing, jreSkipped, jLinkEnabled bool
 
 	pr := libpak.PlanEntryResolver{Plan: context.Plan}
-
-	dr, err := libpak.NewDependencyResolver(context)
-	if err != nil {
-		return libcnb.BuildResult{}, fmt.Errorf("unable to create dependency resolver\n%w", err)
-	}
-
-	dc, err := libpak.NewDependencyCache(context)
-	if err != nil {
-		return libcnb.BuildResult{}, fmt.Errorf("unable to create dependency cache\n%w", err)
-	}
-	dc.Logger = b.Logger
-
-	cl := NewCertificateLoader()
-	cl.Logger = b.Logger.BodyWriter()
-
-	jvmVersion := NewJVMVersion(b.Logger)
-	v, err := jvmVersion.GetJVMVersion(context.Application.Path, cr)
-	if err != nil {
-		return libcnb.BuildResult{}, fmt.Errorf("unable to determine jvm version\n%w", err)
-	}
-
-	jreSkipped := false
-	if t, _ := cr.Resolve("BP_JVM_TYPE"); strings.ToLower(t) == "jdk" {
-		jreSkipped = true
-	}
 
 	_, jdkRequired, err := pr.Resolve("jdk")
 	if err != nil {
@@ -76,100 +61,188 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve jre plan entry\n%w", err)
 	}
 
-	jreAvailable := jreRequired
-	if jreRequired {
-		_, err := dr.Resolve("jre", v)
-		if libpak.IsNoValidDependencies(err) {
-			jreAvailable = false
+	if !jdkRequired && !jreRequired {
+		return b.Result, nil
+	}
+	b.Logger.Title(context.Buildpack)
+
+	cr, err := libpak.NewConfigurationResolver(context.Buildpack, &b.Logger)
+	if err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
+	}
+
+	jvmVersion := NewJVMVersion(b.Logger)
+	v, err := jvmVersion.GetJVMVersion(context.Application.Path, cr)
+	if err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to determine jvm version\n%w", err)
+	}
+
+	dr, err := libpak.NewDependencyResolver(context)
+	if err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to create dependency resolver\n%w", err)
+	}
+
+	b.DependencyCache, err = libpak.NewDependencyCache(context)
+	if err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to create dependency cache\n%w", err)
+	}
+	b.DependencyCache.Logger = b.Logger
+
+	depJDK, err := dr.Resolve("jdk", v)
+	if jdkRequired && err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to find dependency\n%w", err)
+	}
+
+	jreMissing = false
+	depJRE, err := dr.Resolve("jre", v)
+	if libpak.IsNoValidDependencies(err) {
+		jreMissing = true
+	}
+
+	if t, _ := cr.Resolve("BP_JVM_TYPE"); strings.ToLower(t) == "jdk" {
+		jreSkipped = true
+	}
+
+	if jl := cr.ResolveBool("BP_JVM_JLINK_ENABLED"); jl {
+		jLinkEnabled = true
+	}
+
+	// jLink
+	if jLinkEnabled {
+		if IsBeforeJava9(v) {
+			return libcnb.BuildResult{}, fmt.Errorf("unable to build, jlink is compatible with Java 9+ only\n")
+		}
+		if err = b.contributeJDK(depJDK); err != nil {
+			return libcnb.BuildResult{}, fmt.Errorf("unable to contribute JDK for Jlink\n%w", err)
+		}
+		if err = b.contributeJLink(cr, jrePlanEntry.Metadata, context.Application.Path, depJDK); err != nil {
+			return libcnb.BuildResult{}, fmt.Errorf("unable to contribute Jlink\n%w", err)
+		}
+		b.contributeHelpers(context, depJDK)
+		return b.Result, nil
+	}
+
+	// use JDK as JRE
+	if jreRequired && (jreSkipped || jreMissing) {
+		b.warnIfJreNotUsed(jreMissing, jreSkipped)
+		if err = b.contributeJDKAsJRE(depJDK, jrePlanEntry, context); err != nil {
+			return libcnb.BuildResult{}, fmt.Errorf("unable to contribute JDK as JRE\n%w", err)
+		}
+		b.contributeHelpers(context, depJDK)
+		return b.Result, nil
+	}
+
+	// contribute a JDK
+	if jdkRequired {
+		if err = b.contributeJDK(depJDK); err != nil {
+			return libcnb.BuildResult{}, fmt.Errorf("unable to contribute JDK \n%w", err)
 		}
 	}
 
-	// we need a JDK, we're not using the JDK as a JRE and the JRE has not been skipped
-	if jdkRequired && !(jreRequired && !jreAvailable) && !jreSkipped {
-		dep, err := dr.Resolve("jdk", v)
-		if err != nil {
-			return libcnb.BuildResult{}, fmt.Errorf("unable to find dependency\n%w", err)
-		}
-
-		jdk, be, err := NewJDK(dep, dc, cl)
-		if err != nil {
-			return libcnb.BuildResult{}, fmt.Errorf("unable to create jdk\n%w", err)
-		}
-
-		jdk.Logger = b.Logger
-		result.Layers = append(result.Layers, jdk)
-		result.BOM.Entries = append(result.BOM.Entries, be)
-	}
-
+	// contribute a JRE
 	if jreRequired {
 		dt := JREType
-		depJRE, err := dr.Resolve("jre", v)
-
-		if !jreAvailable || jreSkipped {
-			b.warnIfJreNotUsed(jreAvailable, jreSkipped)
-
-			// This forces the contributed layer to be build + cache + launch so it's available everywhere
-			jrePlanEntry.Metadata["build"] = true
-			jrePlanEntry.Metadata["cache"] = true
-
-			dt = JDKType
-			depJRE, err = dr.Resolve("jdk", v)
+		if err = b.contributeJRE(depJRE, context.Application.Path, dt, jrePlanEntry.Metadata); err != nil {
+			return libcnb.BuildResult{}, fmt.Errorf("unable to contribute JDK \n%w", err)
 		}
-
-		if err != nil {
-			return libcnb.BuildResult{}, fmt.Errorf("unable to find dependency\n%w", err)
-		}
-
-		jre, be, err := NewJRE(context.Application.Path, depJRE, dc, dt, cl, jrePlanEntry.Metadata)
-		if err != nil {
-			return libcnb.BuildResult{}, fmt.Errorf("unable to create jre\n%w", err)
-		}
-
-		jre.Logger = b.Logger
-		result.Layers = append(result.Layers, jre)
-		result.BOM.Entries = append(result.BOM.Entries, be)
-
 		if IsLaunchContribution(jrePlanEntry.Metadata) {
-			helpers := []string{"active-processor-count", "java-opts", "jvm-heap", "link-local-dns", "memory-calculator",
-				"security-providers-configurer", "jmx", "jfr"}
-
-			if IsBeforeJava9(depJRE.Version) {
-				helpers = append(helpers, "security-providers-classpath-8")
-				helpers = append(helpers, "debug-8")
-			} else {
-				helpers = append(helpers, "security-providers-classpath-9")
-				helpers = append(helpers, "debug-9")
-				helpers = append(helpers, "nmt")
-			}
-			// Java 18 bug - cacerts keystore type not readable
-			if IsBeforeJava18(depJRE.Version) {
-				helpers = append(helpers, "openssl-certificate-loader")
-			}
-
-			h, be := libpak.NewHelperLayer(context.Buildpack, helpers...)
-			h.Logger = b.Logger
-			result.Layers = append(result.Layers, h)
-			result.BOM.Entries = append(result.BOM.Entries, be)
-
-			jsp := NewJavaSecurityProperties(context.Buildpack.Info)
-			jsp.Logger = b.Logger
-			result.Layers = append(result.Layers, jsp)
+			b.contributeHelpers(context, depJRE)
 		}
 	}
 
-	return result, nil
+	return b.Result, nil
 }
 
-func (b Build) warnIfJreNotUsed(jreAvailable, jreSkipped bool) {
+func (b *Build) contributeJDK(jdkDep libpak.BuildpackDependency) error {
+	jdk, be, err := NewJDK(jdkDep, b.DependencyCache, b.CertLoader)
+	if err != nil {
+		return fmt.Errorf("unable to create jdk\n%w", err)
+	}
+
+	jdk.Logger = b.Logger
+	b.Result.Layers = append(b.Result.Layers, jdk)
+	b.Result.BOM.Entries = append(b.Result.BOM.Entries, be)
+	return nil
+}
+
+func (b *Build) contributeJDKAsJRE(jdkDep libpak.BuildpackDependency, jrePlanEntry libcnb.BuildpackPlanEntry, context libcnb.BuildContext) error {
+	// This forces the contributed layer to be build + cache + launch so it's available everywhere
+	jrePlanEntry.Metadata["build"] = true
+	jrePlanEntry.Metadata["cache"] = true
+
+	dt := JDKType
+	if err := b.contributeJRE(jdkDep, context.Application.Path, dt, jrePlanEntry.Metadata); err != nil {
+		return fmt.Errorf("unable to contribute JRE\n%w", err)
+	}
+	return nil
+}
+
+func (b *Build) contributeJRE(jreDep libpak.BuildpackDependency, appPath string, distributionType DistributionType, metadata map[string]interface{}) error {
+	jre, be, err := NewJRE(appPath, jreDep, b.DependencyCache, distributionType, b.CertLoader, metadata)
+	if err != nil {
+		return fmt.Errorf("unable to create jdk\n%w", err)
+	}
+
+	jre.Logger = b.Logger
+	b.Result.Layers = append(b.Result.Layers, jre)
+	b.Result.BOM.Entries = append(b.Result.BOM.Entries, be)
+	return nil
+}
+
+func (b *Build) contributeJLink(configurationResolver libpak.ConfigurationResolver, planEntryMetadata map[string]interface{}, appPath string, jdkDep libpak.BuildpackDependency) error {
+	args, explicit := configurationResolver.Resolve("BP_JVM_JLINK_ARGS")
+	argList, err := shellwords.Parse(args)
+	if err != nil {
+		return fmt.Errorf("unable to parse jlink arguments %s %w\n", args, err)
+	}
+
+	jlink, err := NewJLink(appPath, effect.NewExecutor(), argList, b.CertLoader, planEntryMetadata, explicit)
+	if err != nil {
+		return fmt.Errorf("unable to create jlink jre\n%w", err)
+	}
+	jlink.JavaVersion = jdkDep.Version
+	jlink.Logger = b.Logger
+	b.Result.Layers = append(b.Result.Layers, jlink)
+	return nil
+}
+
+func (b *Build) contributeHelpers(context libcnb.BuildContext, depJRE libpak.BuildpackDependency) {
+	helpers := []string{"active-processor-count", "java-opts", "jvm-heap", "link-local-dns", "memory-calculator",
+		"security-providers-configurer", "jmx", "jfr"}
+
+	if IsBeforeJava9(depJRE.Version) {
+		helpers = append(helpers, "security-providers-classpath-8")
+		helpers = append(helpers, "debug-8")
+	} else {
+		helpers = append(helpers, "security-providers-classpath-9")
+		helpers = append(helpers, "debug-9")
+		helpers = append(helpers, "nmt")
+	}
+	// Java 18 bug - cacerts keystore type not readable
+	if IsBeforeJava18(depJRE.Version) {
+		helpers = append(helpers, "openssl-certificate-loader")
+	}
+
+	h, be := libpak.NewHelperLayer(context.Buildpack, helpers...)
+	h.Logger = b.Logger
+	b.Result.Layers = append(b.Result.Layers, h)
+	b.Result.BOM.Entries = append(b.Result.BOM.Entries, be)
+
+	jsp := NewJavaSecurityProperties(context.Buildpack.Info)
+	jsp.Logger = b.Logger
+	b.Result.Layers = append(b.Result.Layers, jsp)
+}
+
+func (b Build) warnIfJreNotUsed(jreMissing, jreSkipped bool) {
 	msg := "Using a JDK at runtime has security implications."
 
-	if !jreAvailable && !jreSkipped {
+	if jreMissing && !jreSkipped {
 		msg = fmt.Sprintf("No valid JRE available, providing matching JDK instead. %s", msg)
 	}
 
 	if jreSkipped {
 		subMsg := "A JDK was specifically requested by the user"
-		if jreAvailable {
+		if !jreMissing {
 			subMsg = fmt.Sprintf("%s, however a JRE is available", subMsg)
 		} else {
 			subMsg = fmt.Sprintf("%s and a JDK is the only option", subMsg)

--- a/build_test.go
+++ b/build_test.go
@@ -17,6 +17,8 @@
 package libjvm_test
 
 import (
+	"github.com/paketo-buildpacks/libpak/bard"
+	"io"
 	"os"
 	"testing"
 
@@ -48,7 +50,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		}
 		ctx.StackID = "test-stack-id"
 
-		result, err := libjvm.Build{}.Build(ctx)
+		result, err := libjvm.NewBuild(bard.NewLogger(io.Discard)).Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(result.Layers).To(HaveLen(1))
@@ -74,7 +76,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		}
 		ctx.StackID = "test-stack-id"
 
-		result, err := libjvm.Build{}.Build(ctx)
+		result, err := libjvm.NewBuild(bard.NewLogger(io.Discard)).Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(result.Layers).To(HaveLen(3))
@@ -102,7 +104,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		}
 		ctx.StackID = "test-stack-id"
 
-		result, err := libjvm.Build{}.Build(ctx)
+		result, err := libjvm.NewBuild(bard.NewLogger(io.Discard)).Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(result.Layers[1].(libpak.HelperLayerContributor).Names).To(Equal([]string{
@@ -133,7 +135,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		}
 		ctx.StackID = "test-stack-id"
 
-		result, err := libjvm.Build{}.Build(ctx)
+		result, err := libjvm.NewBuild(bard.NewLogger(io.Discard)).Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(result.Layers[1].(libpak.HelperLayerContributor).Names).To(Equal([]string{
@@ -166,7 +168,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		}
 		ctx.StackID = "test-stack-id"
 
-		result, err := libjvm.Build{}.Build(ctx)
+		result, err := libjvm.NewBuild(bard.NewLogger(io.Discard)).Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(result.Layers[0].Name()).To(Equal("jdk"))
@@ -195,7 +197,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		}
 		ctx.StackID = "test-stack-id"
 
-		result, err := libjvm.Build{}.Build(ctx)
+		result, err := libjvm.NewBuild(bard.NewLogger(io.Discard)).Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(result.Layers[0].Name()).To(Equal("jdk"))
@@ -249,7 +251,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}
 			ctx.StackID = "test-stack-id"
 
-			result, err := libjvm.Build{}.Build(ctx)
+			result, err := libjvm.NewBuild(bard.NewLogger(io.Discard)).Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(result.Layers[0].(libjvm.JDK).LayerContributor.Dependency.Version).To(Equal("1.1.1"))
@@ -284,7 +286,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}
 			ctx.StackID = "test-stack-id"
 
-			result, err := libjvm.Build{}.Build(ctx)
+			result, err := libjvm.NewBuild(bard.NewLogger(io.Discard)).Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Layers[0].Name()).To(Equal("jdk"))
 			Expect(result.Layers[0].(libjvm.JRE).LayerContributor.Dependency.ID).To(Equal("jdk"))
@@ -314,7 +316,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}
 			ctx.StackID = "test-stack-id"
 
-			result, err := libjvm.Build{}.Build(ctx)
+			result, err := libjvm.NewBuild(bard.NewLogger(io.Discard)).Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Layers[0].Name()).To(Equal("jdk"))
 			Expect(result.Layers[0].(libjvm.JDK).LayerContributor.Dependency.ID).To(Equal("jdk"))

--- a/go.mod
+++ b/go.mod
@@ -13,18 +13,22 @@ require (
 	github.com/paketo-buildpacks/libpak v1.60.1
 	github.com/pavel-v-chernykh/keystore-go/v4 v4.3.0
 	github.com/sclevine/spec v1.4.0
+	github.com/stretchr/testify v1.7.1
 	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8
 )
 
 require (
 	github.com/BurntSushi/toml v1.1.0 // indirect
 	github.com/creack/pty v1.1.18 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/h2non/filetype v1.1.3 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
@@ -32,4 +36,5 @@ require (
 	golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/init_test.go
+++ b/init_test.go
@@ -38,6 +38,7 @@ func TestUnit(t *testing.T) {
 	suite("JavaSecurityProperties", testJavaSecurityProperties)
 	suite("JDK", testJDK)
 	suite("JRE", testJRE)
+	suite("JLink", testJLink)
 	suite("NewManifest", testNewManifest)
 	suite("NewManifestFromJAR", testNewManifestFromJAR)
 	suite("MavenJARListing", testMavenJARListing)

--- a/jlink.go
+++ b/jlink.go
@@ -1,0 +1,200 @@
+package libjvm
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/buildpacks/libcnb"
+	"github.com/heroku/color"
+	"github.com/magiconair/properties"
+	"github.com/paketo-buildpacks/libjvm/count"
+	"github.com/paketo-buildpacks/libpak"
+	"github.com/paketo-buildpacks/libpak/bard"
+	"github.com/paketo-buildpacks/libpak/effect"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type JLink struct {
+	LayerContributor  libpak.LayerContributor
+	Logger            bard.Logger
+	ApplicationPath   string
+	Executor          effect.Executor
+	CertificateLoader CertificateLoader
+	Metadata          map[string]interface{}
+	JavaVersion       string
+	Args              []string
+	UserConfigured    bool
+}
+
+func NewJLink(applicationPath string, exec effect.Executor, args []string, certificateLoader CertificateLoader, metadata map[string]interface{}, userConfigured bool) (JLink, error) {
+	expected := map[string]interface{}{"jlink-args": args}
+	if md, err := certificateLoader.Metadata(); err != nil {
+		return JLink{}, fmt.Errorf("unable to generate certificate loader metadata\n%w", err)
+	} else {
+		for k, v := range md {
+			expected[k] = v
+		}
+	}
+	contributor := libpak.NewLayerContributor(
+		"JLink",
+		expected,
+		libcnb.LayerTypes{
+			Build:  IsBuildContribution(metadata),
+			Cache:  IsBuildContribution(metadata),
+			Launch: IsLaunchContribution(metadata),
+		})
+
+	return JLink{
+		LayerContributor:  contributor,
+		Executor:          exec,
+		CertificateLoader: certificateLoader,
+		Metadata:          metadata,
+		ApplicationPath:   applicationPath,
+		Args:              args,
+		UserConfigured:    userConfigured,
+	}, nil
+}
+
+func (j JLink) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
+	j.LayerContributor.Logger = j.Logger
+
+	return j.LayerContributor.Contribute(layer, func() (libcnb.Layer, error) {
+
+		if err := os.RemoveAll(layer.Path); err != nil {
+			return libcnb.Layer{}, fmt.Errorf("unable to remove jlink layer dir \n%w", err)
+		}
+
+		valid := true
+		if j.UserConfigured {
+			valid = j.validArgs()
+		}
+		if !j.UserConfigured || !valid {
+			modules, err := j.listJVMModules(layer.Path)
+			if err != nil {
+				return libcnb.Layer{}, fmt.Errorf("unable to retrieve list of JVM modules for jlink\n%w", err)
+			}
+			j.Args = append(j.Args, "--add-modules", modules)
+		}
+
+		j.Args = append(j.Args, "--output", layer.Path)
+		if err := j.buildCustomJRE(layer.Path); err != nil {
+			return libcnb.Layer{}, fmt.Errorf("unable to build custom JRE with jlink \n%w", err)
+		}
+
+		cacertsPath := filepath.Join(layer.Path, "lib", "security", "cacerts")
+
+		if IsBeforeJava18(j.JavaVersion) {
+			if err := j.CertificateLoader.Load(cacertsPath, "changeit"); err != nil {
+				return libcnb.Layer{}, fmt.Errorf("unable to load certificates\n%w", err)
+			}
+		} else {
+			j.Logger.Bodyf("%s: The JVM cacerts entries cannot be loaded with Java 18, for more information see: https://github.com/paketo-buildpacks/libjvm/issues/158", color.YellowString("Warning"))
+		}
+
+		if IsBuildContribution(j.Metadata) {
+			layer.BuildEnvironment.Default("JAVA_HOME", layer.Path)
+		}
+
+		if IsLaunchContribution(j.Metadata) {
+			layer.LaunchEnvironment.Default("BPI_APPLICATION_PATH", j.ApplicationPath)
+			layer.LaunchEnvironment.Default("BPI_JVM_CACERTS", cacertsPath)
+
+			if c, err := count.Classes(layer.Path); err != nil {
+				return libcnb.Layer{}, fmt.Errorf("unable to count JVM classes\n%w", err)
+			} else {
+				layer.LaunchEnvironment.Default("BPI_JVM_CLASS_COUNT", c)
+			}
+
+			file := filepath.Join(layer.Path, "conf", "security", "java.security")
+
+			p, err := properties.LoadFile(file, properties.UTF8)
+			if err != nil {
+				return libcnb.Layer{}, fmt.Errorf("unable to read properties file %s\n%w", file, err)
+			}
+			p = p.FilterStripPrefix("security.provider.")
+
+			var providers []string
+			for k, v := range p.Map() {
+				providers = append(providers, fmt.Sprintf("%s|%s", k, v))
+			}
+			sort.Strings(providers)
+			layer.LaunchEnvironment.Default("BPI_JVM_SECURITY_PROVIDERS", strings.Join(providers, " "))
+
+			layer.LaunchEnvironment.Default("JAVA_HOME", layer.Path)
+			layer.LaunchEnvironment.Default("MALLOC_ARENA_MAX", "2")
+
+			layer.LaunchEnvironment.Append("JAVA_TOOL_OPTIONS", " ", "-XX:+ExitOnOutOfMemoryError")
+		}
+
+		return layer, nil
+	})
+}
+
+func (j JLink) Name() string {
+	return j.LayerContributor.Name
+}
+
+func (j *JLink) buildCustomJRE(layerPath string) error {
+
+	if err := j.Executor.Execute(effect.Execution{
+		Command: filepath.Join(filepath.Dir(layerPath), "jdk", "bin", "jlink"),
+		Args:    j.Args,
+		Stdout:  j.Logger.Logger.InfoWriter(),
+		Stderr:  j.Logger.Logger.InfoWriter(),
+	}); err != nil {
+		return fmt.Errorf("unable to run jlink\n%w", err)
+	}
+	return nil
+}
+
+func (j *JLink) validArgs() bool {
+	jlinkArgs := j.Args[:0]
+	var skipNext, modsFound bool
+	for _, a := range j.Args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		a = strings.ToLower(a)
+		if strings.HasPrefix(a, "--output") {
+			j.Logger.Bodyf(color.New(color.Faint, color.Bold).Sprint("WARNING: explicitly specified '--output' option & value will be overridden"))
+			skipNext = true
+			continue
+		}
+		if strings.HasPrefix(a, "--add-modules") {
+			modsFound = true
+		}
+		jlinkArgs = append(jlinkArgs, a)
+	}
+	j.Args = jlinkArgs
+	if !modsFound {
+		j.Logger.Bodyf(color.New(color.Faint, color.Bold).Sprint("WARNING: jlink args provided but no modules specified, default JVM modules will be added"))
+	}
+	return modsFound
+}
+
+func (j *JLink) listJVMModules(layerPath string) (string, error) {
+	var mods []string
+	buf := &bytes.Buffer{}
+	if err := j.Executor.Execute(effect.Execution{
+		Command: filepath.Join(filepath.Dir(layerPath), "jdk", "bin", "java"),
+		Args:    []string{"--list-modules"},
+		Stdout:  buf,
+		Stderr:  j.Logger.Logger.InfoWriter(),
+	}); err != nil {
+		return "", fmt.Errorf("unable to list modules\n%w", err)
+	}
+	m := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	for _, mod := range m {
+		if strings.HasPrefix(mod, "java.") {
+			if strings.Contains(mod, "@") {
+				mod = strings.Split(mod, "@")[0]
+			}
+			mods = append(mods, mod)
+		}
+	}
+	modList := strings.Join(mods, ",")
+	return modList, nil
+}

--- a/jlink_test.go
+++ b/jlink_test.go
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libjvm_test
+
+import (
+	"github.com/paketo-buildpacks/libpak/crush"
+	"github.com/paketo-buildpacks/libpak/effect"
+	"github.com/paketo-buildpacks/libpak/effect/mocks"
+	"github.com/stretchr/testify/mock"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/buildpacks/libcnb"
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/libpak/bard"
+	"github.com/sclevine/spec"
+
+	"github.com/paketo-buildpacks/libjvm"
+)
+
+func testJLink(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		cl = libjvm.CertificateLoader{
+			CertDirs: []string{filepath.Join("testdata", "certificates")},
+			Logger:   ioutil.Discard,
+		}
+
+		ctx libcnb.BuildContext
+	)
+
+	it.Before(func() {
+		var err error
+		Expect(os.Setenv("BP_JVM_JLINK_ENABLED", "true")).To(Succeed())
+
+		ctx.Layers.Path, err = ioutil.TempDir("", "jdk")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(ctx.Layers.Path)).To(Succeed())
+		Expect(os.Unsetenv("BP_JVM_JLINK_ENABLED")).To(Succeed())
+
+	})
+
+	it("contributes jlink JRE with default args", func() {
+
+		args := []string{"--no-man-pages", "--no-header-files", "--strip-debug"}
+		exec := &mocks.Executor{}
+		j, err := libjvm.NewJLink(ctx.Application.Path, exec, args, cl, LaunchContribution, false)
+		Expect(err).NotTo(HaveOccurred())
+		j.Logger = bard.NewLogger(ioutil.Discard)
+
+		Expect(j.LayerContributor.ExpectedMetadata.(map[string]interface{})["cert-dir"]).To(HaveLen(4))
+
+		layer, err := ctx.Layers.Layer("jlink")
+		Expect(err).NotTo(HaveOccurred())
+
+		exec.On("Execute", mock.MatchedBy(func(ex effect.Execution) bool {
+			return reflect.DeepEqual(ex.Args, []string{"--list-modules"})
+		})).Return(func(ex effect.Execution) error {
+			_, err := ex.Stdout.Write([]byte("java.se,java.base"))
+			Expect(err).ToNot(HaveOccurred())
+			return nil
+		})
+
+		exec.On("Execute", mock.MatchedBy(func(ex effect.Execution) bool {
+			return strings.Contains(ex.Command, "jlink")
+		})).Run(func(args mock.Arguments) {
+			err = os.MkdirAll(filepath.Join(ctx.Layers.Path, "jlink"), os.ModePerm)
+			jre, err := os.Open("testdata/3aa01010c0d3592ea248c8353d60b361231fa9bf9a7479b4f06451fef3e64524/stub-jre-11.tar.gz")
+			Expect(err).NotTo(HaveOccurred())
+			err = crush.Extract(jre, layer.Path, 1)
+			Expect(err).NotTo(HaveOccurred())
+		}).Return(nil)
+
+		layer, err = j.Contribute(layer)
+		Expect(err).NotTo(HaveOccurred())
+
+		e := exec.Calls[1].Arguments[0].(effect.Execution)
+		Expect(e.Args).To(ContainElement("--add-modules"))
+		Expect(e.Args).To(ContainElement("java.se,java.base"))
+		Expect(e.Args).To(ContainElement("--output"))
+	})
+
+	it("contributes jlink JRE with user provided args & modules", func() {
+
+		args := []string{"--no-man-pages", "--no-header-files", "--strip-debug", "--add-modules", "java.se"}
+		exec := &mocks.Executor{}
+		j, err := libjvm.NewJLink(ctx.Application.Path, exec, args, cl, LaunchContribution, true)
+		Expect(err).NotTo(HaveOccurred())
+		j.Logger = bard.NewLogger(ioutil.Discard)
+
+		Expect(j.LayerContributor.ExpectedMetadata.(map[string]interface{})["cert-dir"]).To(HaveLen(4))
+
+		layer, err := ctx.Layers.Layer("jlink")
+		Expect(err).NotTo(HaveOccurred())
+
+		exec.On("Execute", mock.Anything).Run(func(args mock.Arguments) {
+			err = os.MkdirAll(filepath.Join(ctx.Layers.Path, "jlink"), os.ModePerm)
+			jre, err := os.Open("testdata/3aa01010c0d3592ea248c8353d60b361231fa9bf9a7479b4f06451fef3e64524/stub-jre-11.tar.gz")
+			Expect(err).NotTo(HaveOccurred())
+			err = crush.Extract(jre, layer.Path, 1)
+			Expect(err).NotTo(HaveOccurred())
+		}).Return(nil)
+
+		layer, err = j.Contribute(layer)
+		Expect(err).NotTo(HaveOccurred())
+
+		e := exec.Calls[0].Arguments[0].(effect.Execution)
+		Expect(e.Args).To(ContainElement("--output"))
+		Expect(e.Args).To(ContainElement("--add-modules"))
+		Expect(e.Args).To(ContainElement("java.se"))
+	})
+
+	it("contributes jlink JRE with user provided args & missing modules", func() {
+
+		args := []string{"--no-man-pages", "--no-header-files", "--strip-debug"}
+		exec := &mocks.Executor{}
+		j, err := libjvm.NewJLink(ctx.Application.Path, exec, args, cl, LaunchContribution, true)
+		Expect(err).NotTo(HaveOccurred())
+		j.Logger = bard.NewLogger(ioutil.Discard)
+
+		Expect(j.LayerContributor.ExpectedMetadata.(map[string]interface{})["cert-dir"]).To(HaveLen(4))
+
+		layer, err := ctx.Layers.Layer("jlink")
+		Expect(err).NotTo(HaveOccurred())
+
+		exec.On("Execute", mock.MatchedBy(func(ex effect.Execution) bool {
+			return strings.Contains(ex.Command, "java")
+		})).Return(func(ex effect.Execution) error {
+			_, err := ex.Stdout.Write([]byte("java.se,java.base"))
+			Expect(err).ToNot(HaveOccurred())
+			return nil
+		})
+
+		exec.On("Execute", mock.MatchedBy(func(ex effect.Execution) bool {
+			return strings.Contains(ex.Command, "jlink")
+		})).Run(func(args mock.Arguments) {
+			err = os.MkdirAll(filepath.Join(ctx.Layers.Path, "jlink"), os.ModePerm)
+			jre, err := os.Open("testdata/3aa01010c0d3592ea248c8353d60b361231fa9bf9a7479b4f06451fef3e64524/stub-jre-11.tar.gz")
+			Expect(err).NotTo(HaveOccurred())
+			err = crush.Extract(jre, layer.Path, 1)
+			Expect(err).NotTo(HaveOccurred())
+		}).Return(nil)
+
+		layer, err = j.Contribute(layer)
+		Expect(err).NotTo(HaveOccurred())
+
+		e := exec.Calls[1].Arguments[0].(effect.Execution)
+		Expect(e.Args).To(ContainElement("--add-modules"))
+		Expect(e.Args).To(ContainElement("java.se,java.base"))
+		Expect(e.Args).To(ContainElement("--output"))
+	})
+
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary

Resolves #3 
Supersedes  #174 

Adds support for the following env variables which allow for the creation of a custom JRE when a JDK is being used as a JRE.

`BP_JVM_JLINK_ENABLED` - default false (initially at least). When set to true this will result in the execution of the JDK tool jlink to create a custom JRE with the following default arguments:
--add-modules <jvm modules> - adds default JRE modules from output of `java --list-modules` (modules matching java.*)
--no-man-pages - excludes man pages
--no-header-files - excludes header files
--strip-debug - strips debug information
--compress=1 - sets compression type = constant string sharing

`BP_JVM_JLINK_ARGS` - this can be set to supply custom arguments to the jlink tool. The output argument should not be supplied as libjvm will handle the newly created runtime's location. If this is set with any args, the default args will not be used.
The custom JRE will replace the buildpack's default JDK that will be used at runtime.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
