### PR TITLE
Disables loading certificates when NIK is used with Java 18+

### DIFF
--- a/jdk.go
+++ b/jdk.go
@@ -88,7 +88,7 @@ func (j JDK) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 				return libcnb.Layer{}, fmt.Errorf("unable to load certificates\n%w", err)
 			}
 		} else {
-			j.Logger.Bodyf("%s: The JVM cacerts entries cannot be loaded with Java 18, for more information see: https://github.com/paketo-buildpacks/libjvm/issues/158", color.YellowString("Warning"))
+			j.Logger.Bodyf("%s: The JVM cacerts entries cannot be loaded with Java 18+, for more information see: https://github.com/paketo-buildpacks/libjvm/issues/158", color.YellowString("Warning"))
 		}
 		return layer, nil
 	})

--- a/jlink.go
+++ b/jlink.go
@@ -93,7 +93,7 @@ func (j JLink) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 				return libcnb.Layer{}, fmt.Errorf("unable to load certificates\n%w", err)
 			}
 		} else {
-			j.Logger.Bodyf("%s: The JVM cacerts entries cannot be loaded with Java 18, for more information see: https://github.com/paketo-buildpacks/libjvm/issues/158", color.YellowString("Warning"))
+			j.Logger.Bodyf("%s: The JVM cacerts entries cannot be loaded with Java 18+, for more information see: https://github.com/paketo-buildpacks/libjvm/issues/158", color.YellowString("Warning"))
 		}
 
 		if IsBuildContribution(j.Metadata) {

--- a/jre.go
+++ b/jre.go
@@ -94,7 +94,7 @@ func (j JRE) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 				return libcnb.Layer{}, fmt.Errorf("unable to load certificates\n%w", err)
 			}
 		} else {
-			j.Logger.Bodyf("%s: The JVM cacerts entries cannot be loaded with Java 18, for more information see: https://github.com/paketo-buildpacks/libjvm/issues/158", color.YellowString("Warning"))
+			j.Logger.Bodyf("%s: The JVM cacerts entries cannot be loaded with Java 18+, for more information see: https://github.com/paketo-buildpacks/libjvm/issues/158", color.YellowString("Warning"))
 		}
 
 		if IsBuildContribution(j.Metadata) {

--- a/nik.go
+++ b/nik.go
@@ -123,8 +123,12 @@ func (n NIK) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			return  libcnb.Layer{}, fmt.Errorf("unable to set keystore file permissions\n%w", err)
 		}
 
-		if err := n.CertificateLoader.Load(keyStorePath, "changeit"); err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to load certificates\n%w", err)
+		if IsBeforeJava18(n.JDKDependency.Version) {
+			if err := n.CertificateLoader.Load(keyStorePath, "changeit"); err != nil {
+				return libcnb.Layer{}, fmt.Errorf("unable to load certificates\n%w", err)
+			}
+		} else {
+			n.Logger.Bodyf("%s: The JVM cacerts entries cannot be loaded with Java 18+, for more information see: https://github.com/paketo-buildpacks/libjvm/issues/158", color.YellowString("Warning"))
 		}
 
 		if n.NativeDependency != nil {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
The JDK and JRE paths both check the Java version when determining whether the certificates should be loaded - this was not necessary for NIK until now when we have support for NIK+Java 19 in GraalVM

## Use Cases
Allows native builds to succeed without cacerts feature for Java 19.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
