### PR TITLE
Use required version of buildPlanEntry, e.g. a specific jdk

### DIFF
--- a/init_test.go
+++ b/init_test.go
@@ -46,5 +46,6 @@ func TestUnit(t *testing.T) {
 	suite("SDKMAN", testSDKMAN)
 	suite("Versions", testVersions)
 	suite("JVMVersions", testJVMVersion)
+	suite("MetadataVersion", testResolveMetadataVersion)
 	suite.Run(t)
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Allow the metada of a buildplan to request a specific version of the dependency.

## Use Cases
This could be an implementation of [rfc #268](https://github.com/paketo-buildpacks/rfcs/pull/268) which would allow more flexibility and the buildpacks to be less coupled.

This would allow use cases like [issue #217](https://github.com/paketo-buildpacks/maven/issues/217).

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
