### PR TITLE
Do not add debug options if already available in JAVA_TOOL_OPTIONS

### DIFF
--- a/helper/debug_8.go
+++ b/helper/debug_8.go
@@ -18,6 +18,7 @@ package helper
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/paketo-buildpacks/libpak/bard"
 	"github.com/paketo-buildpacks/libpak/sherpa"
@@ -30,6 +31,14 @@ type Debug8 struct {
 func (d Debug8) Execute() (map[string]string, error) {
 
 	if val := sherpa.ResolveBool("BPL_DEBUG_ENABLED"); !val {
+		return nil, nil
+	}
+
+	opts := sherpa.GetEnvWithDefault("JAVA_TOOL_OPTIONS", "")
+	debugAlreadyExists := strings.Contains(opts, "-agentlib:jdwp=")
+
+	if debugAlreadyExists {
+		d.Logger.Info("Java agent 'jdwp' already configured")
 		return nil, nil
 	}
 
@@ -49,7 +58,7 @@ func (d Debug8) Execute() (map[string]string, error) {
 		s = "n"
 	}
 
-	opts := sherpa.AppendToEnvVar("JAVA_TOOL_OPTIONS", " ", fmt.Sprintf("-agentlib:jdwp=transport=dt_socket,server=y,address=%s,suspend=%s", port, s))
+	opts = sherpa.AppendToEnvVar("JAVA_TOOL_OPTIONS", " ", fmt.Sprintf("-agentlib:jdwp=transport=dt_socket,server=y,address=%s,suspend=%s", port, s))
 
 	return map[string]string{"JAVA_TOOL_OPTIONS": opts}, nil
 }

--- a/helper/debug_8_test.go
+++ b/helper/debug_8_test.go
@@ -53,6 +53,20 @@ func testDebug8(t *testing.T, context spec.G, it spec.S) {
 			}))
 		})
 
+		context("jdwp agent already configured", func() {
+			it.Before(func() {
+				Expect(os.Setenv("JAVA_TOOL_OPTIONS", "-agentlib:jdwp=something")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("JAVA_TOOL_OPTIONS")).To(Succeed())
+			})
+
+			it("does not update JAVA_TOOL_OPTIONS", func() {
+				Expect(d.Execute()).To(BeEmpty())
+			})
+		})
+
 		context("$BPL_DEBUG_PORT", func() {
 			it.Before(func() {
 				Expect(os.Setenv("BPL_DEBUG_PORT", "8001")).To(Succeed())

--- a/helper/debug_9.go
+++ b/helper/debug_9.go
@@ -18,6 +18,7 @@ package helper
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/paketo-buildpacks/libpak/sherpa"
 
@@ -31,6 +32,14 @@ type Debug9 struct {
 func (d Debug9) Execute() (map[string]string, error) {
 
 	if val := sherpa.ResolveBool("BPL_DEBUG_ENABLED"); !val {
+		return nil, nil
+	}
+
+	opts := sherpa.GetEnvWithDefault("JAVA_TOOL_OPTIONS", "")
+	debugAlreadyExists := strings.Contains(opts, "-agentlib:jdwp=")
+
+	if debugAlreadyExists {
+		d.Logger.Info("Java agent 'jdwp' already configured")
 		return nil, nil
 	}
 
@@ -50,7 +59,7 @@ func (d Debug9) Execute() (map[string]string, error) {
 		s = "n"
 	}
 
-	opts := sherpa.AppendToEnvVar("JAVA_TOOL_OPTIONS", " ", fmt.Sprintf("-agentlib:jdwp=transport=dt_socket,server=y,address=%s,suspend=%s", port, s))
+	opts = sherpa.AppendToEnvVar("JAVA_TOOL_OPTIONS", " ", fmt.Sprintf("-agentlib:jdwp=transport=dt_socket,server=y,address=%s,suspend=%s", port, s))
 
 	return map[string]string{"JAVA_TOOL_OPTIONS": opts}, nil
 }

--- a/helper/debug_9_test.go
+++ b/helper/debug_9_test.go
@@ -52,6 +52,20 @@ func testDebug9(t *testing.T, context spec.G, it spec.S) {
 			}))
 		})
 
+		context("jdwp agent already configured", func() {
+			it.Before(func() {
+				Expect(os.Setenv("JAVA_TOOL_OPTIONS", "-agentlib:jdwp=something")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("JAVA_TOOL_OPTIONS")).To(Succeed())
+			})
+
+			it("does not update JAVA_TOOL_OPTIONS", func() {
+				Expect(d.Execute()).To(BeEmpty())
+			})
+		})
+
 		context("$BPL_DEBUG_PORT", func() {
 			it.Before(func() {
 				Expect(os.Setenv("BPL_DEBUG_PORT", "8001")).To(Succeed())


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
fixes #274 

## Summary
<!-- A short explanation of the proposed change -->
If the java agent is already configured via `JAVA_TOOL_OPTIONS`, it is not added a second time since this would cause an error when starting the java process.

## Use Cases
<!-- An explanation of the use cases your change enables -->
see issue

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
