### PR TITLE
Remove the Calculation for Active Processor Count

### DIFF
--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -37,7 +37,7 @@ func main() {
 
 			cl = libjvm.NewCertificateLoader()
 
-			a  = helper.ActiveProcessorCount{Logger: l}
+			// a  = helper.ActiveProcessorCount{Logger: l}
 			c  = helper.SecurityProvidersConfigurer{Logger: l}
 			d  = helper.LinkLocalDNS{Logger: l}
 			j  = helper.JavaOpts{Logger: l}
@@ -65,7 +65,7 @@ func main() {
 		}
 
 		return sherpa.Helpers(map[string]sherpa.ExecD{
-			"active-processor-count":         a,
+			// "active-processor-count":         a,
 			"java-opts":                      j,
 			"jvm-heap":                       jh,
 			"link-local-dns":                 d,


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Remove the Active Processor Count calculation from main helper since it is not right

## Use Cases

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
