### PR TITLE
Load existing certs from pkcs12 store

### DIFF
--- a/certificate_loader.go
+++ b/certificate_loader.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/paketo-buildpacks/libpak/sherpa"
-	"golang.org/x/sys/unix"
 )
 
 const DefaultCertFile = "/etc/ssl/certs/ca-certificates.crt"
@@ -56,10 +55,6 @@ func NewCertificateLoader() CertificateLoader {
 }
 
 func (c *CertificateLoader) Load(path string, password string) error {
-	if unix.Access(path, unix.W_OK) != nil {
-		return nil
-	}
-
 	ks, err := DetectKeystore(path)
 	if err != nil {
 		return err

--- a/certificate_loader.go
+++ b/certificate_loader.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/paketo-buildpacks/libpak/sherpa"
+	"golang.org/x/sys/unix"
 )
 
 const DefaultCertFile = "/etc/ssl/certs/ca-certificates.crt"
@@ -55,6 +56,10 @@ func NewCertificateLoader() CertificateLoader {
 }
 
 func (c *CertificateLoader) Load(path string, password string) error {
+	if unix.Access(path, unix.W_OK) != nil {
+		return nil
+	}
+
 	ks, err := DetectKeystore(path)
 	if err != nil {
 		return err

--- a/certificate_loader_test.go
+++ b/certificate_loader_test.go
@@ -155,11 +155,7 @@ func testCertificateLoader(t *testing.T, context spec.G, it spec.S) {
 			Expect(ks).To(HaveLen(3))
 		})
 
-		if internal.IsRoot() {
-			return
-		}
-
-		it("does not return error when keystore is read-only", func() {
+		internal.SkipIfRoot(it, "does not return error when keystore is read-only", func() {
 			Expect(os.Chmod(path, 0555)).To(Succeed())
 
 			c := libjvm.CertificateLoader{
@@ -256,11 +252,7 @@ func testCertificateLoader(t *testing.T, context spec.G, it spec.S) {
 			Expect(ks.Aliases()).To(HaveLen(3))
 		})
 
-		if internal.IsRoot() {
-			return
-		}
-
-		it("does not return error when keystore is read-only", func() {
+		internal.SkipIfRoot(it, "does not return error when keystore is read-only", func() {
 			Expect(os.Chmod(path, 0555)).To(Succeed())
 
 			c := libjvm.CertificateLoader{

--- a/helper/link_local_dns_test.go
+++ b/helper/link_local_dns_test.go
@@ -90,11 +90,7 @@ networkaddress.cache.negative.ttl=0
 `)))
 		})
 
-		if internal.IsRoot() {
-			return
-		}
-
-		it("warns if file is read-only", func() {
+		internal.SkipIfRoot(it, "warns if file is read-only", func() {
 			Expect(os.Chmod(path, 0555)).To(Succeed())
 
 			config := &ddns.ClientConfig{Servers: []string{"169.254.0.1"}}

--- a/helper/openssl_certificate_loader_test.go
+++ b/helper/openssl_certificate_loader_test.go
@@ -98,11 +98,7 @@ func testOpenSSLCertificateLoader(t *testing.T, context spec.G, it spec.S) {
 			Expect(ks.Aliases()).To(HaveLen(3))
 		})
 
-		if internal.IsRoot() {
-			return
-		}
-
-		it("does use temp keystore if keystore is read-only", func() {
+		internal.SkipIfRoot(it, "does use temp keystore if keystore is read-only", func() {
 			Expect(os.Chmod(path, 0555)).To(Succeed())
 
 			o := helper.OpenSSLCertificateLoader{CertificateLoader: cl, Logger: bard.NewLogger(ioutil.Discard)}
@@ -122,7 +118,7 @@ func testOpenSSLCertificateLoader(t *testing.T, context spec.G, it spec.S) {
 			Expect(env).To(HaveKeyWithValue("JAVA_TOOL_OPTIONS", fmt.Sprintf("-Djavax.net.ssl.trustStore=%s", helper.TmpTrustStore)))
 		})
 
-		it("does not return error when keystore and /tmp/truststore are read-only", func() {
+		internal.SkipIfRoot(it, "does not return error when keystore and /tmp/truststore are read-only", func() {
 			Expect(os.Chmod(path, 0555)).To(Succeed())
 			_, err := os.OpenFile(helper.TmpTrustStore, os.O_CREATE, 0)
 			Expect(err).NotTo(HaveOccurred())

--- a/helper/security_providers_configurer_test.go
+++ b/helper/security_providers_configurer_test.go
@@ -106,11 +106,7 @@ security.provider.6=FOXTROT
 `)))
 				})
 
-				if internal.IsRoot() {
-					return
-				}
-
-				it("warns if the file is read-only", func() {
+				internal.SkipIfRoot(it, "warns if the file is read-only", func() {
 					Expect(os.Chmod(path, 0555)).To(Succeed())
 
 					Expect(helper.SecurityProvidersConfigurer{}.Execute()).To(BeNil())

--- a/internal/if_not_root.go
+++ b/internal/if_not_root.go
@@ -18,9 +18,18 @@ package internal
 
 import (
 	"os/user"
+
+	"github.com/sclevine/spec"
 )
 
-func IsRoot() bool {
+func isRoot() bool {
 	u, _ := user.Current()
 	return u.Username == "root"
+}
+
+func SkipIfRoot(it spec.S, text string, f func(), options ...spec.Option) {
+	if isRoot() {
+		it = it.Pend
+	}
+	it(text, f, options...)
 }

--- a/keystore.go
+++ b/keystore.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"github.com/pavlo-v-chernykh/keystore-go/v4"
+	"golang.org/x/sys/unix"
 	"software.sslmate.com/src/go-pkcs12"
 )
 
@@ -90,6 +91,10 @@ func (k *JKSKeystore) Add(name string, b *pem.Block) error {
 }
 
 func (k *JKSKeystore) Write() error {
+	if unix.Access(k.location, unix.W_OK) != nil {
+		return nil
+	}
+
 	out, err := os.OpenFile(k.location, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("unable to open %s\n%w", k.location, err)
@@ -154,6 +159,10 @@ func (k *PasswordLessPKCS12Keystore) Add(name string, b *pem.Block) error {
 }
 
 func (k *PasswordLessPKCS12Keystore) Write() error {
+	if unix.Access(k.location, unix.W_OK) != nil {
+		return nil
+	}
+
 	out, err := os.OpenFile(k.location, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
 		return err

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -97,7 +97,8 @@ func testKeystore(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("can be written", func() {
-			ks := libjvm.NewPasswordLessPKCS12Keystore(path)
+			ks, err := libjvm.NewPasswordLessPKCS12Keystore(path)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(ks.Len()).To(Equal(1))
 			cert, err := os.ReadFile(filepath.Join("testdata", "cert.pem"))
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
When writing a `pkcs12` key store, we read first the existing certificates like done in the `jks` case. The implementation did remove any existing certs before.

Downport of https://github.com/paketo-buildpacks/libjvm/pull/346

## Use Cases
<!-- An explanation of the use cases your change enables -->
The keystore provided by the `JRE` already contains some certificates.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
