### PR TITLE
Support jre-skipped in Build Plan

### DIFF
--- a/build.go
+++ b/build.go
@@ -81,7 +81,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 	pr := libpak.PlanEntryResolver{Plan: context.Plan}
 
-	_, jdkRequired, err := pr.Resolve("jdk")
+	jdkPlanEntry, jdkRequired, err := pr.Resolve("jdk")
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve jdk plan entry\n%w", err)
 	}
@@ -135,6 +135,9 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	}
 
 	if t, _ := cr.Resolve("BP_JVM_TYPE"); strings.ToLower(t) == "jdk" {
+		jreSkipped = true
+	}
+	if _, jreSkippedExists := jdkPlanEntry.Metadata["jre-skipped"]; jreSkippedExists {
 		jreSkipped = true
 	}
 

--- a/build_test.go
+++ b/build_test.go
@@ -17,8 +17,10 @@
 package libjvm_test
 
 import (
+	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/paketo-buildpacks/libpak/bard"
@@ -60,6 +62,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"id":      "jdk",
 					"version": "1.1.1",
 					"stacks":  []interface{}{"test-stack-id"},
+					"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 				},
 			},
 		}
@@ -86,6 +89,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"id":      "jre",
 					"version": "1.1.1",
 					"stacks":  []interface{}{"test-stack-id"},
+					"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 				},
 			},
 		}
@@ -114,6 +118,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"id":      "jre",
 					"version": "8.0.0",
 					"stacks":  []interface{}{"test-stack-id"},
+					"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 				},
 			},
 		}
@@ -145,6 +150,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"id":      "jre",
 					"version": "11.0.0",
 					"stacks":  []interface{}{"test-stack-id"},
+					"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 				},
 			},
 		}
@@ -178,6 +184,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"id":      "jdk",
 					"version": "1.1.1",
 					"stacks":  []interface{}{"test-stack-id"},
+					"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 				},
 			},
 		}
@@ -207,6 +214,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"id":      "jdk",
 					"version": "1.1.1",
 					"stacks":  []interface{}{"test-stack-id"},
+					"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 				},
 			},
 		}
@@ -226,6 +234,30 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(result.BOM.Entries[1].Launch).To(BeTrue())
 	})
 
+	it("contributes JDK as JRE when jre-skipped is set in the build plan", func() {
+		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jdk", Metadata: map[string]interface{}{
+			"jre-skipped": true,
+		}})
+		ctx.Buildpack.API = "0.6"
+		ctx.Buildpack.Metadata = map[string]interface{}{
+			"dependencies": []map[string]interface{}{
+				{
+					"id":      "jdk",
+					"version": "1.1.1",
+					"stacks":  []interface{}{"test-stack-id"},
+					"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
+				},
+			},
+		}
+		ctx.StackID = "test-stack-id"
+
+		result, err := libjvm.NewBuild(bard.NewLogger(io.Discard)).Build(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(result.Layers).To(HaveLen(1))
+		Expect(result.Layers[0].Name()).To(Equal("jdk"))
+	})
+
 	it("contributes NIK API <= 0.6", func() {
 
 		ctx.Plan.Entries = append(
@@ -239,6 +271,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"id":      "native-image-svm",
 					"version": "1.1.1",
 					"stacks":  []interface{}{"test-stack-id"},
+					"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 				},
 			},
 		}
@@ -270,7 +303,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"version": "1.1.1",
 					"stacks":  []interface{}{"test-stack-id"},
 					"cpes":    []interface{}{"cpe:2.3:a:bellsoft:nik:1.1.1:*:*:*:*:*:*:*"},
-					"purl":    "pkg:generic/provider-nik@1.1.1?arch=amd64",
+					"purl":    fmt.Sprintf("pkg:generic/provider-nik@1.1.1??arch=%s", runtime.GOARCH),
 				},
 			},
 		}
@@ -306,14 +339,14 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						"version": "1.1.1",
 						"stacks":  []interface{}{"test-stack-id"},
 						"cpes":    []string{"cpe:2.3:a:oracle:graalvm:21.2.0:*:*:*:community:*:*:*"},
-						"purl":    "pkg:generic/graalvm-jdk@21.2.0",
+						"purl":    fmt.Sprintf("pkg:generic/graalvm-jdk@21.2.0?arch=%s", runtime.GOARCH),
 					},
 					{
 						"id":      "native-image-svm",
 						"version": "2.2.2",
 						"stacks":  []interface{}{"test-stack-id"},
 						"cpes":    []string{"cpe:2.3:a:oracle:graalvm:21.2.0:*:*:*:community:*:*:*"},
-						"purl":    "pkg:generic/graalvm-svm@21.2.0",
+						"purl":    fmt.Sprintf("pkg:generic/graalvm-svm@21.2.0?arch=%s", runtime.GOARCH),
 					},
 				},
 			}
@@ -354,14 +387,14 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						"version": "1.1.1",
 						"stacks":  []interface{}{"test-stack-id"},
 						"cpes":    []string{"cpe:2.3:a:oracle:graalvm:21.2.0:*:*:*:community:*:*:*"},
-						"purl":    "pkg:generic/graalvm-jdk@21.2.0",
+						"purl":    fmt.Sprintf("pkg:generic/graalvm-jdk@21.2.0?arch=%s", runtime.GOARCH),
 					},
 					{
 						"id":      "native-image-svm",
 						"version": "2.2.2",
 						"stacks":  []interface{}{"test-stack-id"},
 						"cpes":    []string{"cpe:2.3:a:oracle:graalvm:21.2.0:*:*:*:community:*:*:*"},
-						"purl":    "pkg:generic/graalvm-svm@21.2.0",
+						"purl":    fmt.Sprintf("pkg:generic/graalvm-svm@21.2.0?arch=%s", runtime.GOARCH),
 					},
 				},
 			}
@@ -387,6 +420,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"id":      "native-image-svm",
 					"version": "1.1.1",
 					"stacks":  []interface{}{"test-stack-id"},
+					"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 				},
 			},
 		}
@@ -425,21 +459,25 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						"id":      "jdk",
 						"version": "1.1.1",
 						"stacks":  []interface{}{"test-stack-id"},
+						"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 					},
 					{
 						"id":      "jdk",
 						"version": "2.2.2",
 						"stacks":  []interface{}{"test-stack-id"},
+						"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 					},
 					{
 						"id":      "jre",
 						"version": "1.1.1",
 						"stacks":  []interface{}{"test-stack-id"},
+						"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 					},
 					{
 						"id":      "jre",
 						"version": "2.2.2",
 						"stacks":  []interface{}{"test-stack-id"},
+						"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 					},
 				},
 			}
@@ -470,11 +508,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						"id":      "jdk",
 						"version": "0.0.2",
 						"stacks":  []interface{}{"test-stack-id"},
+						"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 					},
 					{
 						"id":      "jre",
 						"version": "2.2.2",
 						"stacks":  []interface{}{"test-stack-id"},
+						"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 					},
 				},
 			}
@@ -500,11 +540,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						"id":      "jdk",
 						"version": "0.0.1",
 						"stacks":  []interface{}{"test-stack-id"},
+						"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 					},
 					{
 						"id":      "jre",
 						"version": "1.1.1",
 						"stacks":  []interface{}{"test-stack-id"},
+						"purl":    fmt.Sprintf("?arch=%s", runtime.GOARCH),
 					},
 				},
 			}


### PR DESCRIPTION
Allow libjvm based buildpacks to be required by other buildpacks that also insist the JDK is provided at runtime instead of a JRE.

fixes #378 

## Summary
Reads the metadata of the buildplan to see if `jre-skipped` is required.

## Use Cases
The main use-case is where a "frontend" buildpack needs to determine whether a JDK is required at runtime or not.

## Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
