### PR TITLE
Only contribute active-processor-count helper for Java versions < 17

### DIFF
--- a/build.go
+++ b/build.go
@@ -272,7 +272,7 @@ func (b *Build) contributeNIK(jdkDep libpak.BuildpackDependency, nativeDep libpa
 }
 
 func (b *Build) contributeHelpers(context libcnb.BuildContext, depJRE libpak.BuildpackDependency) {
-	helpers := []string{"active-processor-count", "java-opts", "jvm-heap", "link-local-dns", "memory-calculator",
+	helpers := []string{"java-opts", "jvm-heap", "link-local-dns", "memory-calculator",
 		"security-providers-configurer", "jmx", "jfr", "openssl-certificate-loader"}
 
 	if IsBeforeJava9(depJRE.Version) {
@@ -283,6 +283,11 @@ func (b *Build) contributeHelpers(context libcnb.BuildContext, depJRE libpak.Bui
 		helpers = append(helpers, "debug-9")
 		helpers = append(helpers, "nmt")
 	}
+
+	if IsBeforeJava17(depJRE.Version) {
+		helpers = append(helpers, "active-processor-count")
+	}
+
 	found := false
 	for _, custom := range b.CustomHelpers {
 		if found {

--- a/versions.go
+++ b/versions.go
@@ -21,6 +21,7 @@ import (
 )
 
 var Java9, _ = semver.NewVersion("9")
+var Java17, _ = semver.NewVersion("17")
 var Java18, _ = semver.NewVersion("18")
 
 func IsBeforeJava9(candidate string) bool {
@@ -30,6 +31,15 @@ func IsBeforeJava9(candidate string) bool {
 	}
 
 	return v.LessThan(Java9)
+}
+
+func IsBeforeJava17(candidate string) bool {
+	v, err := semver.NewVersion(candidate)
+	if err != nil {
+		return false
+	}
+
+	return v.LessThan(Java17)
 }
 
 func IsBeforeJava18(candidate string) bool {

--- a/versions_test.go
+++ b/versions_test.go
@@ -37,4 +37,17 @@ func testVersions(t *testing.T, context spec.G, it spec.S) {
 		Expect(libjvm.IsBeforeJava9("")).To(BeFalse())
 	})
 
+	it("determins whether a version is before Java 18", func() {
+		Expect(libjvm.IsBeforeJava18("17.0.0")).To(BeTrue())
+		Expect(libjvm.IsBeforeJava18("18.0.0")).To(BeFalse())
+		Expect(libjvm.IsBeforeJava18("19.0.0")).To(BeFalse())
+		Expect(libjvm.IsBeforeJava18("")).To(BeFalse())
+	})
+
+	it("determines whether a version is before Java 17", func() {
+		Expect(libjvm.IsBeforeJava17("16.0.0")).To(BeTrue())
+		Expect(libjvm.IsBeforeJava17("17.0.0")).To(BeFalse())
+		Expect(libjvm.IsBeforeJava17("18.0.0")).To(BeFalse())
+		Expect(libjvm.IsBeforeJava17("")).To(BeFalse())
+	})
 }


### PR DESCRIPTION
## Summary
The active processor count helper is still valuable for older versions of Java which do not handle processor detection well. Recent versions of Java have this capability built into them, so this PR stops adding the active-processor-count helper for Java 17+.

## Use Cases
Resolves #136. This is one option though, so let's get some feedback on this before merging.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
