### PR TITLE
enhancement(link_local_dns.go): avoid occur runtime panic when the nameservers are empty.

### DIFF
--- a/helper/link_local_dns.go
+++ b/helper/link_local_dns.go
@@ -32,6 +32,12 @@ type LinkLocalDNS struct {
 }
 
 func (l LinkLocalDNS) Execute() (map[string]string, error) {
+	// In some cases, the nameservers are empty.
+	// For example, when using the host network, and host '/etc/resolv.conf' file content is empty.
+	if len(l.Config.Servers) == 0 {
+		return nil, nil
+	}
+
 	if !net.ParseIP(l.Config.Servers[0]).IsLinkLocalUnicast() {
 		return nil, nil
 	}

--- a/helper/link_local_dns_test.go
+++ b/helper/link_local_dns_test.go
@@ -59,6 +59,15 @@ func testLinkLocalDNS(t *testing.T, context spec.G, it spec.S) {
 		Expect(ioutil.ReadFile(path)).To(Equal([]byte("test")))
 	})
 
+	it("do nothing if no nameservers", func() {
+		config := &ddns.ClientConfig{Servers: []string{}}
+
+		l := helper.LinkLocalDNS{Config: config}
+
+		Expect(l.Execute()).To(BeNil())
+		Expect(ioutil.ReadFile(path)).To(Equal([]byte(`test`)))
+	})
+
 	it("returns an error if $JAVA_SECURITY_PROPERTIES is not set", func() {
 		config := &ddns.ClientConfig{Servers: []string{"169.254.0.1"}}
 		l := helper.LinkLocalDNS{Config: config}


### PR DESCRIPTION
## Summary

Use `return` to instead of `runtime panic` if there no nameservers are found in /etc/resolve.conf

In the following case, the nameservers are empty

The container uses the host network but the nameserver is empty in the host file

## Use Cases

If nameservers are empty, no runtime panic

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
