### PR TITLE
Fix premature log in LinkLocalDNS.Execute function

### DIFF
--- a/helper/link_local_dns.go
+++ b/helper/link_local_dns.go
@@ -51,8 +51,6 @@ func (l LinkLocalDNS) Execute() (map[string]string, error) {
 		return nil, nil
 	}
 
-	l.Logger.Info("JVM DNS caching disabled in favor of link-local DNS caching")
-
 	f, err := os.OpenFile(file, os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open %s\n%w", file, err)
@@ -66,6 +64,9 @@ networkaddress.cache.negative.ttl=0
 	if err != nil {
 		return nil, fmt.Errorf("unable to write DNS configuration to %s\n%w", file, err)
 	}
+
+	// Log the success message only after the file write is confirmed.
+	l.Logger.Info("JVM DNS caching disabled in favor of link-local DNS caching")
 
 	return nil, nil
 }


### PR DESCRIPTION


<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The log message "JVM DNS caching disabled in favor of link-local DNS caching" was being printed before successfully writing the required changes to the JVM settings file. This could mislead users into thinking the operation completed successfully, even if the write operation failed.

Changes made:
- Deferred the success log to occur only after confirming the changes have been successfully written to the file.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
